### PR TITLE
Rwd update

### DIFF
--- a/mir-verifier.cabal
+++ b/mir-verifier.cabal
@@ -39,6 +39,7 @@ library
                    Mir.Mir
 
   other-modules: 
+                 Mir.Intrinsics,
                  Mir.Pass,
                  Mir.Pass.CollapseRefs,
                  Mir.Pass.MutRefReturnStatic,

--- a/mir-verifier.cabal
+++ b/mir-verifier.cabal
@@ -40,5 +40,10 @@ library
 
   other-modules: 
                  Mir.Pass,
+                 Mir.Pass.CollapseRefs,
+                 Mir.Pass.MutRefReturnStatic,
+                 Mir.Pass.RewriteMutRef,
+                 Mir.Pass.RemoveStorage,
+                 Mir.Pass.RemoveBoxNullary,
                  Mir.Run,
                  Mir.Trans

--- a/src/Mir/Intrinsics.hs
+++ b/src/Mir/Intrinsics.hs
@@ -1,0 +1,341 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+-- See: https://ghc.haskell.org/trac/ghc/ticket/11581
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wincomplete-patterns #-}
+
+module Mir.Intrinsics
+( MirReferenceSymbol
+, MirReferenceType
+, pattern MirReferenceRepr
+, MirReference(..)
+, MirReferencePath(..)
+, muxRefPath
+, muxRef
+, TaggedUnion
+  -- * MIR Syntax extension
+, MIR
+, MirStmt(..)
+, mirExtImpl
+) where
+
+import           GHC.TypeLits
+import           Control.Lens hiding (Empty, (:>), Index)
+import           Control.Monad
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Maybe
+
+import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
+
+import           Data.Parameterized.Classes
+import           Data.Parameterized.Context
+import           Data.Parameterized.TraversableFC
+import qualified Data.Parameterized.TH.GADT as U
+
+import           Lang.Crucible.CFG.Extension
+import           Lang.Crucible.FunctionHandle
+import           Lang.Crucible.Types
+import           Lang.Crucible.Simulator.CallFns
+import           Lang.Crucible.Simulator.ExecutionTree
+import           Lang.Crucible.Simulator.Evaluation
+import           Lang.Crucible.Simulator.GlobalState
+import           Lang.Crucible.Simulator.Intrinsics
+import           Lang.Crucible.Simulator.RegValue
+import           Lang.Crucible.Simulator.RegMap
+import           Lang.Crucible.Simulator.SimError
+import           Lang.Crucible.Solver.Interface
+import           Lang.Crucible.Solver.Partial
+import           Lang.Crucible.Utils.MonadST
+import qualified Lang.Crucible.Utils.Structural as U
+
+
+type MirReferenceSymbol = "MirReference"
+type MirReferenceType tp = IntrinsicType MirReferenceSymbol (EmptyCtx ::> tp)
+
+pattern MirReferenceRepr :: () => tp' ~ MirReferenceType tp => TypeRepr tp -> TypeRepr tp'
+pattern MirReferenceRepr tp <-
+     IntrinsicRepr (testEquality (knownSymbol @MirReferenceSymbol) -> Just Refl) (Empty :> tp)
+ where MirReferenceRepr tp = IntrinsicRepr (knownSymbol @MirReferenceSymbol) (Empty :> tp)
+
+type family MirReferenceFam (sym :: *) (ctx :: Ctx CrucibleType) :: * where
+  MirReferenceFam sym (EmptyCtx ::> tp) = MirReference sym tp
+  MirReferenceFam sym ctx = TypeError ('Text "MirRefeence expects a single argument, but was given" ':<>:
+                                       'ShowType ctx)
+instance IsExprBuilder sym => IntrinsicClass sym MirReferenceSymbol where
+  type Intrinsic sym MirReferenceSymbol ctx = MirReferenceFam sym ctx
+
+  muxIntrinsic sym _nm (Empty :> tp) = muxRef sym
+  muxIntrinsic _sym nm ctx = typeError nm ctx
+
+data MirReferencePath sym :: CrucibleType -> CrucibleType -> * where
+  Empty_RefPath :: MirReferencePath sym tp tp
+  Field_RefPath ::
+    !(CtxRepr ctx) ->
+    !(MirReferencePath sym tp_base TaggedUnion) ->
+    !(Index ctx tp) ->
+    MirReferencePath sym tp_base tp
+  Index_RefPath ::
+    !(TypeRepr tp) ->
+    !(MirReferencePath sym tp_base (VectorType tp)) ->
+    !(RegValue sym NatType) ->
+    MirReferencePath sym tp_base tp
+
+data MirReference sym (tp :: CrucibleType) where
+  MirReference ::
+    !(RegValue sym (ReferenceType tpr)) ->
+    !(MirReferencePath sym tpr tp) ->
+    MirReference sym tp
+
+muxRefPath ::
+  IsExprBuilder sym =>
+  sym ->
+  Pred sym ->
+  MirReferencePath sym tp_base tp ->
+  MirReferencePath sym tp_base tp ->
+  MaybeT IO (MirReferencePath sym tp_base tp)
+muxRefPath sym c path1 path2 = case (path1,path2) of
+  (Empty_RefPath, Empty_RefPath) -> return Empty_RefPath
+  (Field_RefPath ctx1 p1 f1, Field_RefPath ctx2 p2 f2)
+    | Just Refl <- testEquality ctx1 ctx2
+    , Just Refl <- testEquality f1 f2 ->
+         do p' <- muxRefPath sym c p1 p2
+            return (Field_RefPath ctx1 p' f1)
+  (Index_RefPath tp p1 i1, Index_RefPath _ p2 i2) ->
+         do p' <- muxRefPath sym c p1 p2
+            i' <- lift $ natIte sym c i1 i2
+            return (Index_RefPath tp p' i')
+  _ -> mzero
+
+muxRef :: forall sym tp.
+  IsExprBuilder sym =>
+  sym ->
+  Pred sym ->
+  MirReference sym tp ->
+  MirReference sym tp ->
+  IO (MirReference sym tp)
+muxRef sym c (MirReference r1 p1) (MirReference r2 p2) =
+   runMaybeT action >>= \case
+     Nothing -> fail "Incompatible MIR reference merge"
+     Just x  -> return x
+
+  where
+  action :: MaybeT IO (MirReference sym tp)
+  action =
+    do Refl <- MaybeT (return $ testEquality (refType r1) (refType r2))
+       Refl <- MaybeT (return $ testEquality r1 r2)
+       p' <- muxRefPath sym c p1 p2
+       return (MirReference r1 p')
+
+-- | Sigil type indicating the MIR syntax extension
+data MIR
+type instance ExprExtension MIR = EmptyExprExtension
+type instance StmtExtension MIR = MirStmt
+
+type TaggedUnion = StructType (EmptyCtx ::> NatType ::> AnyType)
+
+data MirStmt :: (CrucibleType -> *) -> CrucibleType -> * where
+  MirNewRef ::
+     !(TypeRepr tp) ->
+     MirStmt f (MirReferenceType tp)
+  MirReadRef ::
+     !(TypeRepr tp) ->
+     !(f (MirReferenceType tp)) ->
+     MirStmt f tp
+  MirWriteRef ::
+     !(f (MirReferenceType tp)) ->
+     !(f tp) ->
+     MirStmt f UnitType
+  MirDropRef ::
+     !(f (MirReferenceType tp)) ->
+     MirStmt f UnitType
+  MirSubfieldRef ::
+     !(CtxRepr ctx) ->
+     !(f (MirReferenceType TaggedUnion)) ->
+     !(Index ctx tp) ->
+     MirStmt f (MirReferenceType tp)
+  MirSubindexRef ::
+     !(TypeRepr tp) ->
+     !(f (MirReferenceType (VectorType tp))) ->
+     !(f NatType) ->
+     MirStmt f (MirReferenceType tp)
+
+$(return [])
+
+
+traverseMirStmt ::
+  Applicative m =>
+  (forall t. e t -> m (f t)) ->
+  (forall t. MirStmt e t -> m (MirStmt f t))
+traverseMirStmt = $(U.structuralTraversal [t|MirStmt|] [])
+
+instance TestEqualityFC MirStmt where
+  testEqualityFC testSubterm =
+    $(U.structuralTypeEquality [t|MirStmt|]
+       [ (U.DataArg 0 `U.TypeApp` U.AnyType, [|testSubterm|])
+       , (U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
+       , (U.ConType [t|CtxRepr|] `U.TypeApp` U.AnyType, [|testEquality|])
+       , (U.ConType [t|Index|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType, [|testEquality|])
+       ])
+instance TestEquality f => TestEquality (MirStmt f) where
+  testEquality = testEqualityFC testEquality
+
+instance OrdFC MirStmt where
+  compareFC compareSubterm =
+    $(U.structuralTypeOrd [t|MirStmt|]
+       [ (U.DataArg 0 `U.TypeApp` U.AnyType, [|compareSubterm|])
+       , (U.ConType [t|TypeRepr|] `U.TypeApp` U.AnyType, [|compareF|])
+       , (U.ConType [t|CtxRepr|] `U.TypeApp` U.AnyType, [|compareF|])
+       , (U.ConType [t|Index|] `U.TypeApp` U.AnyType `U.TypeApp` U.AnyType, [|compareF|])
+       ])
+instance OrdF f => OrdF (MirStmt f) where
+  compareF = compareFC compareF
+
+instance TypeApp MirStmt where
+  appType = \case
+    MirNewRef tp    -> MirReferenceRepr tp
+    MirReadRef tp _ -> tp
+    MirWriteRef _ _ -> UnitRepr
+    MirDropRef _    -> UnitRepr
+    MirSubfieldRef ctx _ idx -> MirReferenceRepr (ctx ! idx)
+    MirSubindexRef tp _ _ -> MirReferenceRepr tp
+
+instance PrettyApp MirStmt where
+  ppApp pp = \case 
+    MirNewRef tp -> "newMirRef" <+> pretty tp
+    MirReadRef _ x  -> "readMirRef" <+> pp x
+    MirWriteRef x y -> "writeMirRef" <+> pp x <+> "<-" <+> pp y
+    MirDropRef x    -> "dropMirRef" <+> pp x
+    MirSubfieldRef _ x idx -> "subfieldRef" <+> pp x <+> text (show idx)
+    MirSubindexRef _ x idx -> "subindexRef" <+> pp x <+> pp idx
+
+instance FunctorFC MirStmt where
+  fmapFC = fmapFCDefault
+instance FoldableFC MirStmt where
+  foldMapFC = foldMapFCDefault
+instance TraversableFC MirStmt where
+  traverseFC = traverseMirStmt
+
+instance IsSyntaxExtension MIR
+
+execMirStmt :: IsSymInterface sym => EvalStmtFunc p sym MIR
+execMirStmt s stmt =
+  let ctx = s^.stateContext
+      sym = ctx^.ctxSymInterface
+      halloc = simHandleAllocator ctx
+      iTypes = ctxIntrinsicTypes ctx
+  in case stmt of
+       MirNewRef tp ->
+         do r <- liftST (freshRefCell halloc tp)
+            let r' = MirReference r Empty_RefPath
+            return (s, r')
+
+       MirDropRef (regValue -> MirReference r path) ->
+         case path of
+           Empty_RefPath ->
+             do let s' = s & stateTree . actFrame . gpGlobals %~ dropRef r
+                return (s', ())
+           _ -> addFailedAssertion sym (GenericSimError "Cannot drop an interior reference")
+
+       MirReadRef _tp (regValue -> MirReference r path) ->
+         do let msg = ReadBeforeWriteSimError
+                       "Attempted to read uninitialized reference cell"
+            v <- readPartExpr sym (lookupRef r (s ^. stateTree . actFrame . gpGlobals)) msg
+            v' <- readRefPath sym iTypes v path
+            return (s, v')
+
+       MirWriteRef (regValue -> MirReference r Empty_RefPath) (regValue -> x) ->
+         do let s' = s & stateTree . actFrame . gpGlobals %~ insertRef sym r x
+            return (s', ())
+       MirWriteRef (regValue -> MirReference r path) (regValue -> x) ->
+         do let msg = ReadBeforeWriteSimError
+                       "Attempted to read uninitialized reference cell"
+            v <- readPartExpr sym (lookupRef r (s ^. stateTree . actFrame . gpGlobals)) msg
+            v' <- writeRefPath sym iTypes v path x
+            let s' = s & stateTree . actFrame . gpGlobals %~ insertRef sym r v'
+            return (s', ())
+       MirSubfieldRef ctx (regValue -> MirReference r path) idx ->
+         do let r' = MirReference r (Field_RefPath ctx path idx)
+            return (s, r')
+       MirSubindexRef tp (regValue -> MirReference r path) (regValue -> idx) ->
+         do let r' = MirReference r (Index_RefPath tp path idx)
+            return (s, r')
+
+writeRefPath :: IsSymInterface sym =>
+  sym ->
+  IntrinsicTypes sym ->
+  RegValue sym tp ->
+  MirReferencePath sym tp tp' ->
+  RegValue sym tp' ->
+  IO (RegValue sym tp)
+writeRefPath sym iTypes v path x =
+  adjustRefPath sym iTypes v path (\_ -> return x)
+
+
+adjustRefPath :: IsSymInterface sym =>
+  sym ->
+  IntrinsicTypes sym ->
+  RegValue sym tp ->
+  MirReferencePath sym tp tp' ->
+  (RegValue sym tp' -> IO (RegValue sym tp')) ->
+  IO (RegValue sym tp)
+adjustRefPath sym iTypes v path0 adj = case path0 of
+  Empty_RefPath -> adj v
+  Field_RefPath ctx path fld ->
+      adjustRefPath sym iTypes v path (field @1 (\(RV (AnyValue vtp x)) ->
+         case testEquality vtp (StructRepr ctx) of
+           Nothing -> fail ("Variant type mismatch! Expected: " ++ show (StructRepr ctx) ++
+                            "\nbut got: " ++ show vtp)
+           Just Refl -> RV . AnyValue vtp <$> adjustM (\x' -> RV <$> adj (unRV x')) fld x
+         ))
+
+  Index_RefPath tp path idx ->
+      adjustRefPath sym iTypes v path (\v' ->
+        adjustVectorWithSymNat sym (muxRegForType sym iTypes tp) v' idx adj)
+
+
+readRefPath :: IsSymInterface sym =>
+  sym ->
+  IntrinsicTypes sym ->
+  RegValue sym tp ->
+  MirReferencePath sym tp tp' ->
+  IO (RegValue sym tp')
+readRefPath sym iTypes v = \case
+  Empty_RefPath -> return v
+  Field_RefPath ctx path fld ->
+    do (Empty :> _disc :> RV (AnyValue vtp variant)) <- readRefPath sym iTypes v path
+       case testEquality vtp (StructRepr ctx) of
+         Nothing -> fail ("Variant type mismatch expected: " ++ show (StructRepr ctx) ++ 
+                           "\nbut got: " ++ show vtp)
+         Just Refl -> return (unRV (variant ! fld))
+  Index_RefPath tp path idx ->
+    do v' <- readRefPath sym iTypes v path
+       indexVectorWithSymNat sym (muxRegForType sym iTypes tp) v' idx
+
+
+mirExtImpl :: IsSymInterface sym => ExtensionImpl p sym MIR
+mirExtImpl = ExtensionImpl
+             { extensionEval = \_ -> \case
+             , extensionExec = execMirStmt
+             }

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -268,7 +268,7 @@ data Var = Var {
     _varmut :: Mutability,
     _varty :: Ty,
     _varscope :: VisibilityScope,
-    _varpos :: String }
+    _varpos :: Text }
     deriving (Eq, Show)
 
 instance Ord Var where
@@ -375,7 +375,7 @@ instance FromJSON BasicBlockData where
         <*>  v .: "terminator"
 
 data Statement =
-      Assign { _alhs :: Lvalue, _arhs :: Rvalue, _apos :: String}
+      Assign { _alhs :: Lvalue, _arhs :: Rvalue, _apos :: Text }
       -- TODO: the rest of these variants also have positions
       | SetDiscriminant { _sdlv :: Lvalue, _sdvi :: Int }
       | StorageLive { _sllv :: Lvalue }

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -193,6 +193,16 @@ data Field = Field {_fName :: Text, _fty :: Ty, _fsubsts :: [Maybe Ty]}
 instance FromJSON Field where
     parseJSON = withObject "Field" $ \v -> Field <$> v .: "name" <*> v .: "ty" <*> v .: "substs"
 
+
+isMutRefTy :: Ty -> Bool
+isMutRefTy (TyRef t m) = (m == Mut) ||  isMutRefTy t
+isMutRefTy (TySlice t) = isMutRefTy t
+isMutRefTy (TyArray t _) = isMutRefTy t
+isMutRefTy (TyTuple ts) = foldl (\acc t -> acc || isMutRefTy t) False ts
+isMutRefTy (TyCustom (BoxTy t)) = isMutRefTy t
+isMutRefTy _ = False
+
+
 data CustomTy =
        BoxTy Ty
       | VecTy Ty

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -14,7 +14,8 @@ import qualified Text.Regex as Regex
 import qualified Data.Map.Strict as Map
 import Data.Text (Text, unpack)
 import Data.List
-import System.IO.Unsafe
+
+import GHC.Stack
 
 -- NOTE: below, all unwinding calls can be ignored
 --
@@ -489,7 +490,7 @@ data Operand =
       | OpConstant Constant
       deriving (Show, Eq)
 
-lValueofOp :: Operand -> Lvalue
+lValueofOp :: HasCallStack => Operand -> Lvalue
 lValueofOp (Consume lv) = lv
 lValueofOp l = error $ "bad lvalue of op: " ++ (show l)
 

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -412,7 +412,7 @@ instance FromJSON Lvalue where
                                               _ -> fail "kind not found"
 
 data Rvalue =
-    Use { _uop :: Operand }
+        Use { _uop :: Operand }
       | Repeat { _rop :: Operand, _rlen :: ConstUsize }
       | Ref { _rbk :: BorrowKind, _rvar :: Lvalue, _rregion :: Text }
       | Len { _lenvar :: Lvalue }
@@ -576,7 +576,7 @@ instance FromJSON Lvpelem where
                                                Just (String "Downcast") -> Downcast <$> v .: "variant"
 
 data NullOp =
-    SizeOf
+        SizeOf
       | Box
       deriving (Show,Eq)
 
@@ -589,7 +589,7 @@ instance FromJSON NullOp where
                                              Just (String "Box") -> pure Box
 
 data BorrowKind =
-    Shared
+        Shared
       | Unique
       | Mutable
       deriving (Show,Eq)

--- a/src/Mir/Pass.hs
+++ b/src/Mir/Pass.hs
@@ -2,27 +2,31 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Mir.Pass (
+    Pass,
     passId,
-    passRemoveStorage,
-    passRemoveBoxNullary,
-    passCollapseRefs,
-    passMutRefArgs
+    isMutRefTy
 ) where
 
 import Mir.Mir
 import Control.Monad.State.Lazy
 import Data.List
-import Control.Monad.Reader
-import Data.Maybe (catMaybes)
 import Control.Lens hiding (op)
 import qualified Data.Text as T
 import qualified Data.Map.Strict as Map
-import System.IO.Unsafe
+--import System.IO.Unsafe
 
--- mir utitiles
---
---
---
+import GHC.Stack
+
+import qualified Debug.Trace as Debug
+
+
+type Pass = Collection -> Collection
+
+passId :: Pass
+passId fns = fns
+
+
+
 
 isMutRefTy :: Ty -> Bool
 isMutRefTy (TyRef t m) = (m == Mut) ||  isMutRefTy t
@@ -32,466 +36,39 @@ isMutRefTy (TyTuple ts) = foldl (\acc t -> acc || isMutRefTy t) False ts
 isMutRefTy (TyCustom (BoxTy t)) = isMutRefTy t
 isMutRefTy _ = False
 
-class IsMutTagged a where
-    isMutTagged :: a -> Bool
 
-instance IsMutTagged Operand where
-    isMutTagged (Consume (Tagged _ "mutchange")) = True
-    isMutTagged _ = False
-
-instance IsMutTagged Lvalue where
-    isMutTagged (Tagged _ "mutchange") = True
-    isMutTagged _ = False
-
-removeTags :: [Operand] -> [Operand]
-removeTags = map (\(Consume ( Tagged lv _)) -> Consume lv)
-
-isMutRefVar :: Var -> Bool
-isMutRefVar (Var _ _ t _) = isMutRefTy t
-
-changeTyToImmut :: Ty -> Ty
-changeTyToImmut (TyRef c _) =  (TyRef c Immut)
-changeTyToImmut t = t
-
+-- mir utitiles
 --
---other utils
-ints_list :: Int -> [Int]
-ints_list 0 = [0]
-ints_list i | i > 0 = (ints_list (i - 1)) ++ [i]
-            | i < 0 = error "bad intslist"
+--
 --
 
-type Pass = Collection -> Collection
-
-passId :: Pass
-passId fns = fns
-
--- Pass for rewriting mutref args to be returned outside; i.e., if I have a function f(x : T1, y : &mut T2, z : T3, w : &mut T4) -> T5, it will be transformed into a function which returns (T5, T2, T4). All function calls are also transformed to handle this. This is done purely at the MIR "syntax" level.
-
--- The algorithm is imperative -- everything is basically modified in place.
-
-data RewriteFnSt = RFS { --  state internal to function translation.
-    _fn_name :: T.Text,
-    _ctr :: Int, -- counter for fresh variables
-    _immut_arguments :: Map.Map T.Text Var, -- arguments to the function which don't need to be tampered with
-    -- vvv arguments of the form &mut T (or variations thereof.) The translation creates a dummy variable for each one. The dummy variable is the second. fst will end up in internals, snd will end up in arguments
-    _mut_argpairs :: Map.Map T.Text (Var, Var),
-    _ret_ty :: Ty,
-    _internals :: Map.Map T.Text Var, -- local variables
-    _blocks :: Map.Map T.Text BasicBlockData,
-    _dummyret :: Maybe Var, -- this is where the original return value goes, which will later be aggregated with the mutref values
-    _fnargsmap :: Map.Map T.Text [Ty], -- maps argument names to their types in the function signature
-    _fnsubstitutions :: Map.Map Lvalue Lvalue -- any substitutions which need to take place. all happen at the end
-    }
-
-fnSubstitutions :: Simple Lens RewriteFnSt (Map.Map Lvalue Lvalue)
-fnSubstitutions = lens _fnsubstitutions (\s v -> s { _fnsubstitutions = v })
-
-fnName :: Simple Lens (RewriteFnSt) T.Text
-fnName = lens _fn_name (\s v -> s { _fn_name = v })
-
-dummy_ctr :: Simple Lens (RewriteFnSt) Int
-dummy_ctr = lens _ctr (\s v -> s { _ctr = v })
-
-fnImmutArguments :: Simple Lens (RewriteFnSt) (Map.Map T.Text Var)
-fnImmutArguments = lens _immut_arguments (\s v -> s { _immut_arguments = v })
-
-fnArgsMap :: Simple Lens (RewriteFnSt) (Map.Map T.Text [Ty])
-fnArgsMap = lens _fnargsmap (\s v -> s { _fnargsmap = v })
-
-fnMutArgPairs :: Simple Lens (RewriteFnSt) (Map.Map T.Text (Var, Var))
-fnMutArgPairs = lens _mut_argpairs (\s v -> s { _mut_argpairs = v })
-
-fnDummyRet :: Simple Lens RewriteFnSt (Maybe Var)
-fnDummyRet = lens _dummyret (\s v -> s { _dummyret = v})
-
-fnRet_ty :: Simple Lens (RewriteFnSt) Ty
-fnRet_ty = lens _ret_ty (\s v -> s { _ret_ty = v })
-
-fnInternals :: Simple Lens (RewriteFnSt) (Map.Map T.Text Var)
-fnInternals = lens _internals (\s v -> s { _internals = v })
-
-fnBlocks :: Simple Lens (RewriteFnSt) (Map.Map T.Text BasicBlockData)
-fnBlocks = lens _blocks (\s v -> s { _blocks = v })
-
-newCtr :: State RewriteFnSt Int
-newCtr = do
-    c <- use dummy_ctr
-    dummy_ctr .= (c + 1)
-    return (c + 1)
-
-newDummyBlock :: T.Text -> BasicBlockData -> State RewriteFnSt BasicBlock
-newDummyBlock prev_name bbd = do
-    blocks <- use fnBlocks
-    let name = T.pack $ (T.unpack prev_name) ++ "d"
-    fnBlocks .= Map.insert name bbd blocks
-    return (BasicBlock name bbd)
-
-mkDummyInternal :: Ty -> State RewriteFnSt Var
-mkDummyInternal ty = do
-    internals <- use fnInternals
-    let dummyvar = (Var "_dummyret" Immut ty "scopedum")
-    fnInternals .= Map.insert "_dummyret" dummyvar internals
-    return dummyvar
-
-newInternal :: Ty -> State RewriteFnSt Var
-newInternal ty = do
-    ctr <- newCtr
-    let new_name = T.pack $ "_vd" ++ (show ctr)
-        new_var =  (Var new_name Immut ty "scopedum")
-    internals <- use fnInternals
-    fnInternals .= Map.insert new_name new_var internals
-    return new_var
-
-removeReturnVar :: [Var] -> [Var]
-removeReturnVar [] = []
-removeReturnVar (v:vs) = case v of
-                           (Var "_0" _ _ _) -> vs
-                           _ -> v : (removeReturnVar vs)
-
-findReturnVar :: [Var] -> Var
-findReturnVar [] = error "return var not found!"
-findReturnVar (v:vs) = case v of
-                         (Var "_0" _ _ _) -> v
-                         _ -> findReturnVar vs
-
-modifyVarTy :: Var -> Ty -> Var
-modifyVarTy (Var a b c d) e = Var a b e d
-
-
-vars_to_map :: [Var] -> Map.Map T.Text Var
-vars_to_map vs = Map.fromList $ map (\v -> (_varname v, v)) vs
-
-mutref_to_immut :: Var -> Var
-mutref_to_immut (Var vn vm vty vsc) = Var (T.pack $ (T.unpack vn) ++ "d") vm (changeTyToImmut vty) vsc
-
--- buildRewriteSt
--- build initial rewrite state
-
-buildRewriteSt :: Fn -> [Fn] -> RewriteFnSt
-buildRewriteSt (Fn fname fargs fretty (MirBody internals blocks)) fns =
-    let (mut_args, immut_args) = partition (isMutRefTy . typeOf) fargs
-        immut_map = vars_to_map immut_args
-        mutpairmap = Map.map (\v -> (v, mutref_to_immut v)) (vars_to_map mut_args)
-        fnmap = Map.fromList $ map (\(Fn fn fa _ _) -> (fn, map typeOf fa)) fns in
-    RFS fname 0 immut_map mutpairmap fretty (vars_to_map internals) (Map.fromList $ map (\bb -> (_bbinfo bb, _bbdata bb)) blocks) Nothing fnmap Map.empty
-
--- insertMutvarsIntoInternals
--- put all x's into internals, where (x,y) are the mutarg pairs (x is old mut, y is new immut dummy)
-
-insertMutvarsIntoInternals :: State RewriteFnSt ()
-insertMutvarsIntoInternals = do
-    mutargpairs <- use fnMutArgPairs
-    forM_ (Map.toList mutargpairs) $ \(vname, (vmut, vimmut)) -> do
-        internals <- use fnInternals
-        fnInternals .= Map.insert vname vmut internals
-
--- modifyAssignEntryBlock
--- insert statements x := y where x is mut ref arg (will be internal), y is corresponding dummy into first block
-modifyAssignEntryBlock :: State RewriteFnSt ()
-modifyAssignEntryBlock = do
-    blocks <- use fnBlocks
-    mutpairs <- use fnMutArgPairs
-    let (BasicBlockData entry_stmts ei) = case Map.lookup (T.pack "bb0") blocks of
-                        Just b -> b
-                        Nothing -> error "entry block not found"
-
-        new_asgns = Map.elems $ Map.map (\(vmut, vimmut) -> Assign (Local vmut) (Use $ Consume $ Local vimmut)) mutpairs
-        new_bbd = BasicBlockData (new_asgns ++ entry_stmts) ei
-    fnBlocks .= Map.insert (T.pack "bb0") new_bbd blocks
-
--- modifyRetData
--- new fretty = (old fretty, x_1, .., x_n) where x_i are mutref types
--- make _0 be new fretty
--- make _dummyret be old fretty
--- replace _0 with _dummyret in blocks
-
-modifyRetData :: State RewriteFnSt ()
-modifyRetData = do
-    old_fretty <- use fnRet_ty
-    mutpairs <- use fnMutArgPairs
-    internals <- use fnInternals
-    let new_fretty = TyTuple $ [old_fretty] ++ (map (_varty . snd) (Map.elems mutpairs))
-    fnRet_ty .= new_fretty
-
-    let (Just retvar) =  Map.lookup "_0" internals
-    fnInternals .= Map.insert "_0" (modifyVarTy retvar new_fretty) internals
-
-    dummy_ret <- mkDummyInternal old_fretty
-    fnDummyRet .= Just (dummy_ret)
-
-    blocks <- use fnBlocks
-    fnBlocks .= replaceVar retvar dummy_ret blocks
-
--- make statement _0 := (_dummyret, x_1, x_2, ..) where x_i are internalized mutable argument
-mkPreReturnAssgn :: State RewriteFnSt Statement
-mkPreReturnAssgn = do
-    mutpairs <- use fnMutArgPairs
-    internals <- use fnInternals
-    let muts = Map.elems $ Map.map fst mutpairs
-    Just dummyret <- use fnDummyRet
-    let (Just retvar) = Map.lookup "_0" internals
-    return $ Assign (Local retvar) (Aggregate AKTuple $  [Consume (Local dummyret)] ++ (map (Consume . Local) muts))
-
-processReturnBlock_ :: BasicBlockData -> State RewriteFnSt BasicBlockData
-processReturnBlock_ (BasicBlockData stmts Return) = do
-    snew <- mkPreReturnAssgn
-    return (BasicBlockData (stmts ++ [snew]) Return)
-
-processReturnBlock_ v = return v
-
--- processReturnBlocks :
-    --  last statement before return becomes _0 := (_dummyret, x_1, x_2, ..) where x_i are the internalized mutable arguments
-processReturnBlocks :: State RewriteFnSt ()
-processReturnBlocks = do
-    blocks <- use fnBlocks
-    newblocks <- mapM processReturnBlock_ blocks
-    fnBlocks .= newblocks
-
--- for the example above where f is taken from returning T5 to (T5, T2, T4), mkFnCallVars creates the dummy variable for receiving the (T5, T2, T4)-value, as well as the corresponding destructures.
-
-mkFnCallVars :: Lvalue -> [Ty] -> State RewriteFnSt (Var, (Lvalue, [Lvalue]))
-mkFnCallVars orig_dest mut_tys = do
-    let type_list = [typeOf orig_dest] ++ mut_tys
-        type_of_new = TyTuple type_list
-    v <- newInternal type_of_new
-    let destructures = zipWith (\ind ty -> LProjection (LvalueProjection (Local v) (PField ind ty))) (ints_list ((length type_list) - 1)) type_list
-    return (v, (head destructures, tail destructures))
-
-    --  for each function call:
-    --     Call(f, args, (ret_lv, dest)) ->
-    --      v := newVar (mkCorrespondingTuple args ret_lv) -- mkCorrespondingTuple args ret_lv = (lv_type, (mut args tupl))
-    --      call(f, args, (Local v, B))
-    --      where B := newDummyBlock $
-    --          destructure v to (orig_return, (mutargs_changed))
-    --          assign ret_lv to orig_return
-    --          assign args to mutargs_changed
-    --          jump to dest
-processFnCall_ :: BasicBlockInfo -> BasicBlockData -> State RewriteFnSt ()
-processFnCall_ bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean))
-    | Just _ <- isCustomFunc (funcNameofOp cfunc) = processCustomFnCall bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean))
-    | otherwise = do
-        fnargsmap <- use fnArgsMap
-        let (mut_cargs, immut_cargs) = sort_mutrefs cargs fnargsmap (funcNameofOp cfunc)
-        if (null mut_cargs) then do
-            return ()
-        else do
-            do_mutrefarg_trans bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean)) mut_cargs
-
-   where sort_mutrefs :: [Operand] -> Map.Map T.Text [Ty] -> T.Text -> ([Operand], [Operand])
-         sort_mutrefs args fnmap fname = case Map.lookup fname fnmap of
-                                           Just tys -> go args tys
-                                           Nothing -> error $ "fn not found: " ++ (show fname)
-
-         go :: [Operand] -> [Ty] -> ([Operand], [Operand])
-         go [] [] = ([], [])
-         go (o:os) (t:ts) = case (isMutRefTy t) of
-                              True -> let (a,b) = go os ts in (o:a, b)
-                              False -> let (a,b) = go os ts in (a, o:b)
-
-         processCustomFnCall :: BasicBlockInfo -> BasicBlockData -> State RewriteFnSt ()
-         processCustomFnCall bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean))
-          | Just "vec_asmutslice" <- isCustomFunc (funcNameofOp cfunc),
-          [op] <- cargs = do -- collapse return var into input.
-              fnsubs <- use fnSubstitutions
-              fnSubstitutions .= Map.insert dest_lv (lValueofOp op) fnsubs
-          | Just "iter_next" <- isCustomFunc (funcNameofOp cfunc), [op] <- cargs = do -- op acts like a mutref.
-            do_mutrefarg_trans bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean)) [op]
-
-          | otherwise = return ()
-
-         do_mutrefarg_trans :: BasicBlockInfo -> BasicBlockData -> [Operand] -> State RewriteFnSt ()
-         do_mutrefarg_trans bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean)) mut_cargs = do
-            (v, (v0, vrest)) <- mkFnCallVars dest_lv $ map typeOf mut_cargs
-            newb <- newDummyBlock bbi $ BasicBlockData
-                ([Assign dest_lv (Use $ Consume v0)] ++ (zipWith (\c v -> Assign (lValueofOp c) (Use $ Consume v)) mut_cargs vrest))
-                (Goto dest_block)
-
-            blocks <- use fnBlocks
-            fnBlocks .= Map.insert bbi (BasicBlockData stmts (Call cfunc cargs (Just (Local v, _bbinfo newb)) cclean)) blocks
-processFnCall_ _ _ = return ()
-
-processFnCalls :: State RewriteFnSt ()
-processFnCalls = do
-    blocks <- use fnBlocks
-    forM_ (Map.toList blocks) $ \(k,v) -> do
-        processFnCall_ k v
-
--- use the state to recover the transformed function
-extractFn :: State RewriteFnSt Fn
-extractFn = do
-    immut_args <- use fnImmutArguments
-    mut_argpairs <- use fnMutArgPairs
-    ret_ty <- use fnRet_ty
-    internals <- use fnInternals
-    blocks <- use fnBlocks
-    fname <- use fnName
-    fsubs <- use fnSubstitutions
-
-    let blocks_ = replaceList (Map.toList fsubs) blocks
-
-    let fnargs = (Map.elems immut_args) ++ (Map.elems $ Map.map snd mut_argpairs)
-        fnblocks = map (\(k,v) -> BasicBlock k v) (Map.toList blocks_)
-    return $ Fn fname fnargs ret_ty (MirBody (Map.elems internals) fnblocks)
-
-
--- if there are no mutref args, then the body of the function doesn't need to change
-needsToBeTransformed :: State RewriteFnSt Bool
-needsToBeTransformed = do
-    mutargpairs <- use fnMutArgPairs
-    return $ not $  Map.null mutargpairs
-
-rewriteMutRefArgFn :: State RewriteFnSt Fn
-rewriteMutRefArgFn = do
-    b <- needsToBeTransformed
-    if b then do
-        modifyAssignEntryBlock
-        modifyRetData
-        processReturnBlocks
-        insertMutvarsIntoInternals
-    else do
-        return ()
-    processFnCalls
-    extractFn
-
-passRewriteMutRefArg :: Pass
-passRewriteMutRefArg fns = map (\fn -> evalState (rewriteMutRefArgFn) (buildRewriteSt fn fns)) fns
-
-passRemoveBoxNullary :: Pass
-passRemoveBoxNullary fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (map removeBoxNullary blocks))) fns
-
-removeBoxNullary :: BasicBlock -> BasicBlock
-removeBoxNullary (BasicBlock bbi (BasicBlockData stmts term)) =
-    let stmts' = filter (\stmt -> case stmt of
-                Assign _ (NullaryOp Box _) -> False
-                _ -> True) stmts
-    in BasicBlock bbi (BasicBlockData stmts' term)
-
-
-mapTransClosure :: Ord a => Map.Map a a -> Map.Map a a
-mapTransClosure m = Map.map (\v -> mapIterate m v) m
-    where mapIterate m v = case (Map.lookup v m) of
-                             Just g -> mapIterate m g
-                             Nothing -> v
-
-passCollapseRefs :: Pass
-passCollapseRefs fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (pcr_ blocks))) fns
-
-pcr_ :: [BasicBlock] -> [BasicBlock]
-pcr_ bs = evalState (pcr bs) (Map.empty)
-
-registerStmt :: Statement -> State (Map.Map Lvalue Lvalue) ()
-registerStmt stmt = do
-    refmap <- get
-    case stmt of
-      Assign lv rv ->
-          if (Map.notMember lv refmap) then
-              case (typeOf lv) of
-                  TyRef _ _ ->
-                      case rv of
-                        Use op ->
-                            do {put $ Map.insert lv (lValueofOp op) refmap}
-                        Ref _ l _ -> do
-                            put $ Map.insert lv l refmap
-                  _ -> return ()
-          else return ()
-      _ -> return ()
-
-pcr :: [BasicBlock] -> State (Map.Map Lvalue Lvalue) [BasicBlock]
-pcr bbs = do
-    forM_ bbs $ \(BasicBlock bbi (BasicBlockData stmts term)) ->
-        forM_ stmts registerStmt
-
-    refmap <- get
-    let refmap_ = mapTransClosure refmap
-    return $ replaceList (Map.toList refmap_) bbs
-
-passMutRefArgs :: Pass
-passMutRefArgs = passRewriteMutRefArg . passCollapseRefs
-
--- remove storageDead / storageAlive calls
-passRemoveStorage :: Pass
-passRemoveStorage fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (prs_ blocks))) fns
-
-prs_ :: [BasicBlock] -> [BasicBlock]
-prs_ bbs = map prs bbs
-
-prs :: BasicBlock -> BasicBlock
-prs (BasicBlock bbi (BasicBlockData stmts t)) =
-    let ns = filter (\stmt -> case stmt of
-                    StorageLive _ -> False
-                    StorageDead _ -> False
-                    _ -> True) stmts in
-    (BasicBlock bbi (BasicBlockData ns t))
-
-exists :: (a -> Bool) -> [a] -> Bool
-exists p xs = case findIndex p xs of
-                Just _ -> True
-                Nothing -> False
-
-forall :: (a -> Bool) -> [a] -> Bool
-forall p xs = not $ exists (not . p) xs
-
-is_branch :: Terminator -> Bool
-is_branch term = case term of
-                   SwitchInt _ _ _ _ -> True
-                   _ -> False
-
-
-is_return_block :: BasicBlock -> Bool
-is_return_block (BasicBlock bbi (BasicBlockData stmts term)) = (term == Return)
-
--- for each function, if it returns a mutable reference, and if the return is statically known to be one of the arguments, perform the corresponding substitution
-
-type MrrsSt = Map.Map T.Text (Maybe Int) -- if component is set, the function returns a mutable reference, and needs to be fused while calling. the integer argument is which argument is the return
-
-build_mrrs_st :: [Fn] -> MrrsSt
-build_mrrs_st fns = Map.fromList $ map (\fn -> (_fname fn, mut_info fn fns)) fns
-
--- determine whether the function statically returns a mutref of an argument. this is true (at least) when there are no switches in the body, and any functions called are themselves static.
-mut_info :: Fn -> [Fn] ->  Maybe Int
-mut_info fn fns =
-    case (is_static_mut_return fns fn) of
-                True -> Just (retrieve_static_mut_return fn)
-                False -> Nothing
-
-is_static_mut_return :: [Fn] -> Fn -> Bool
-is_static_mut_return fns fn =
-    case fn of
-      Fn fname fargs fretty (MirBody internals fblocks) ->
-          case exists (\(BasicBlock _ (BasicBlockData _ term)) -> is_branch term) fblocks of
-            True -> False
-            False ->
-                forall (\(BasicBlock _ (BasicBlockData _ term)) -> (not . is_bad_call) term) fblocks
-
-   where is_bad_call :: Terminator -> Bool
-         is_bad_call term = case term of
-                              Call fname _ _ _ ->
-                                  case find (\(Fn n _ t _) -> n == (funcNameofOp fname)) fns of
-                                    Just call_fn | isMutRefTy (_freturn_ty call_fn) -> (not . (is_static_mut_return fns)) call_fn
-                                    _ -> False
-                              _ -> False
-
-retrieve_static_mut_return :: Fn -> Int
-retrieve_static_mut_return (Fn fname fargs fretty (MirBody internals blocks)) =
-    error "unimplemented" -- find most recent arg index assigned to return variable. the code is guaranteed to be straightline by now, so we can just iterate backwards through the blocks.
-
-
-passMutRefReturnStatic :: Pass
-passMutRefReturnStatic fns = map (\fn -> runReader (mrrs fn) (build_mrrs_st fns)) fns
-
-mrrs :: Fn -> Reader MrrsSt Fn
-mrrs (Fn fname fargs fretty (MirBody d blocks)) = do
-    mrrs_map <- ask
-    let subs = catMaybes $ map (\(BasicBlock bbi (BasicBlockData stmts term)) -> get_sub term mrrs_map) blocks
-
-    return $ Fn fname fargs fretty (MirBody d (replaceList subs blocks))
-
-   where
-       get_sub :: Terminator -> Map.Map T.Text (Maybe Int) -> Maybe (Lvalue, Lvalue)
-       get_sub term mrrs_map = case term of
-         Call opfunc opargs (Just (dest_lv,dest_bbi)) cleanup ->
-             case Map.lookup (funcNameofOp opfunc) mrrs_map of
-               Just (Just i) -> Just ((dest_lv, lValueofOp $ opargs !! i))
-               _ -> Nothing
-         _ -> Nothing
+--isMutRefVar :: Var -> Bool
+--isMutRefVar (Var _ _ t _) = isMutRefTy t
+
+-- class IsMutTagged a where
+--     isMutTagged :: a -> Bool
+
+-- instance IsMutTagged Operand where
+--     isMutTagged (Consume (Tagged _ "mutchange")) = True
+--     isMutTagged _ = False
+
+-- instance IsMutTagged Lvalue where
+--     isMutTagged (Tagged _ "mutchange") = True
+--     isMutTagged _ = False
+
+-- removeTags :: [Operand] -> [Operand]
+-- removeTags = map (\(Consume ( Tagged lv _)) -> Consume lv)
+-- --
+-- --
+
+-- removeReturnVar :: [Var] -> [Var]
+-- removeReturnVar [] = []
+-- removeReturnVar (v:vs) = case v of
+--                            (Var "_0" _ _ _) -> vs
+--                            _ -> v : (removeReturnVar vs)
+
+-- findReturnVar :: [Var] -> Var
+-- findReturnVar [] = error "return var not found!"
+-- findReturnVar (v:vs) = case v of
+--                          (Var "_0" _ _ _) -> v
+--                          _ -> findReturnVar vs

--- a/src/Mir/Pass/CollapseRefs.hs
+++ b/src/Mir/Pass/CollapseRefs.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+module Mir.Pass.CollapseRefs
+( passCollapseRefs
+) where
+ 
+import Control.Lens hiding (op)
+import Control.Monad.State.Lazy
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import Data.List
+
+import Mir.Mir
+import Mir.Pass
+
+import GHC.Stack
+
+mapTransClosure :: Ord a => Map.Map a a -> Map.Map a a
+mapTransClosure m = Map.map (\v -> mapIterate m v) m
+    where mapIterate m v = case (Map.lookup v m) of
+                             Just g -> mapIterate m g
+                             Nothing -> v
+
+passCollapseRefs :: HasCallStack => Pass
+passCollapseRefs fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (pcr_ blocks))) fns
+
+pcr_ :: HasCallStack => [BasicBlock] -> [BasicBlock]
+pcr_ bs = evalState (pcr bs) (Map.empty)
+
+registerStmt :: HasCallStack => Statement -> State (Map.Map Lvalue Lvalue) ()
+registerStmt stmt = do
+    refmap <- get
+    case stmt of
+      Assign lv rv ->
+          if (Map.notMember lv refmap) then
+              case (typeOf lv) of
+                  TyRef _ _ ->
+                      case rv of
+                        Use (Consume lv') ->
+                            put $ Map.insert lv lv' refmap
+                        Ref _ l _ -> do
+                            put $ Map.insert lv l refmap
+                        _ ->
+                            do return ()
+                  _ -> return ()
+          else return ()
+      _ -> return ()
+
+pcr :: HasCallStack => [BasicBlock] -> State (Map.Map Lvalue Lvalue) [BasicBlock]
+pcr bbs = do
+    forM_ bbs $ \(BasicBlock bbi (BasicBlockData stmts term)) ->
+        forM_ stmts registerStmt
+
+    refmap <- get
+    let refmap_ = mapTransClosure refmap
+    return $ replaceList (Map.toList refmap_) bbs
+

--- a/src/Mir/Pass/CollapseRefs.hs
+++ b/src/Mir/Pass/CollapseRefs.hs
@@ -36,7 +36,7 @@ mapTransClosure m = Map.map (\v -> mapIterate m v) m
                              Just g -> mapIterate m g
                              Nothing -> v
 
-passCollapseRefs :: HasCallStack => Collection -> Collection
+passCollapseRefs :: HasCallStack => [Fn] -> [Fn]
 passCollapseRefs fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (pcr_ blocks))) fns
 
 pcr_ :: HasCallStack => [BasicBlock] -> [BasicBlock]

--- a/src/Mir/Pass/MutRefReturnStatic.hs
+++ b/src/Mir/Pass/MutRefReturnStatic.hs
@@ -72,7 +72,7 @@ retrieve_static_mut_return (Fn fname fargs fretty (MirBody internals blocks)) =
     error "unimplemented" -- find most recent arg index assigned to return variable. the code is guaranteed to be straightline by now, so we can just iterate backwards through the blocks.
 
 
-passMutRefReturnStatic :: Collection -> Collection
+passMutRefReturnStatic :: [Fn] -> [Fn]
 passMutRefReturnStatic fns = map (\fn -> runReader (mrrs fn) (build_mrrs_st fns)) fns
 
 mrrs :: Fn -> Reader MrrsSt Fn

--- a/src/Mir/Pass/MutRefReturnStatic.hs
+++ b/src/Mir/Pass/MutRefReturnStatic.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+module Mir.Pass.MutRefReturnStatic
+( passMutRefReturnStatic
+) where
+ 
+import Control.Lens hiding (op)
+import Control.Monad.Reader
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import Data.List
+import Data.Maybe (catMaybes)
+
+import Mir.Mir
+import Mir.Pass
+
+import GHC.Stack
+
+
+exists :: (a -> Bool) -> [a] -> Bool
+exists p xs = case findIndex p xs of
+                Just _ -> True
+                Nothing -> False
+
+forall :: (a -> Bool) -> [a] -> Bool
+forall p xs = not $ exists (not . p) xs
+
+
+
+is_branch :: Terminator -> Bool
+is_branch term = case term of
+                   SwitchInt _ _ _ _ -> True
+                   _ -> False
+
+
+is_return_block :: BasicBlock -> Bool
+is_return_block (BasicBlock bbi (BasicBlockData stmts term)) = (term == Return)
+
+-- for each function, if it returns a mutable reference, and if the return is statically known to be one of the arguments, perform the corresponding substitution
+
+type MrrsSt = Map.Map T.Text (Maybe Int) -- if component is set, the function returns a mutable reference, and needs to be fused while calling. the integer argument is which argument is the return
+
+build_mrrs_st :: [Fn] -> MrrsSt
+build_mrrs_st fns = Map.fromList $ map (\fn -> (_fname fn, mut_info fn fns)) fns
+
+-- determine whether the function statically returns a mutref of an argument. this is true (at least) when there are no switches in the body, and any functions called are themselves static.
+mut_info :: Fn -> [Fn] ->  Maybe Int
+mut_info fn fns =
+    case (is_static_mut_return fns fn) of
+                True -> Just (retrieve_static_mut_return fn)
+                False -> Nothing
+
+is_static_mut_return :: [Fn] -> Fn -> Bool
+is_static_mut_return fns fn =
+    case fn of
+      Fn fname fargs fretty (MirBody internals fblocks) ->
+          case exists (\(BasicBlock _ (BasicBlockData _ term)) -> is_branch term) fblocks of
+            True -> False
+            False ->
+                forall (\(BasicBlock _ (BasicBlockData _ term)) -> (not . is_bad_call) term) fblocks
+
+   where is_bad_call :: Terminator -> Bool
+         is_bad_call term = case term of
+                              Call fname _ _ _ ->
+                                  case find (\(Fn n _ t _) -> n == (funcNameofOp fname)) fns of
+                                    Just call_fn | isMutRefTy (_freturn_ty call_fn) -> (not . (is_static_mut_return fns)) call_fn
+                                    _ -> False
+                              _ -> False
+
+retrieve_static_mut_return :: Fn -> Int
+retrieve_static_mut_return (Fn fname fargs fretty (MirBody internals blocks)) =
+    error "unimplemented" -- find most recent arg index assigned to return variable. the code is guaranteed to be straightline by now, so we can just iterate backwards through the blocks.
+
+
+passMutRefReturnStatic :: Pass
+passMutRefReturnStatic fns = map (\fn -> runReader (mrrs fn) (build_mrrs_st fns)) fns
+
+mrrs :: Fn -> Reader MrrsSt Fn
+mrrs (Fn fname fargs fretty (MirBody d blocks)) = do
+    mrrs_map <- ask
+    let subs = catMaybes $ map (\(BasicBlock bbi (BasicBlockData stmts term)) -> get_sub term mrrs_map) blocks
+
+    return $ Fn fname fargs fretty (MirBody d (replaceList subs blocks))
+
+   where
+       get_sub :: Terminator -> Map.Map T.Text (Maybe Int) -> Maybe (Lvalue, Lvalue)
+       get_sub term mrrs_map = case term of
+         Call opfunc opargs (Just (dest_lv,dest_bbi)) cleanup ->
+             case Map.lookup (funcNameofOp opfunc) mrrs_map of
+               Just (Just i) -> Just ((dest_lv, lValueofOp $ opargs !! i))
+               _ -> Nothing
+         _ -> Nothing

--- a/src/Mir/Pass/MutRefReturnStatic.hs
+++ b/src/Mir/Pass/MutRefReturnStatic.hs
@@ -13,7 +13,6 @@ import Data.List
 import Data.Maybe (catMaybes)
 
 import Mir.Mir
-import Mir.Pass
 
 import GHC.Stack
 
@@ -73,7 +72,7 @@ retrieve_static_mut_return (Fn fname fargs fretty (MirBody internals blocks)) =
     error "unimplemented" -- find most recent arg index assigned to return variable. the code is guaranteed to be straightline by now, so we can just iterate backwards through the blocks.
 
 
-passMutRefReturnStatic :: Pass
+passMutRefReturnStatic :: Collection -> Collection
 passMutRefReturnStatic fns = map (\fn -> runReader (mrrs fn) (build_mrrs_st fns)) fns
 
 mrrs :: Fn -> Reader MrrsSt Fn

--- a/src/Mir/Pass/RemoveBoxNullary.hs
+++ b/src/Mir/Pass/RemoveBoxNullary.hs
@@ -27,7 +27,7 @@ import Mir.Mir
 
 import GHC.Stack
 
-passRemoveBoxNullary :: Collection -> Collection
+passRemoveBoxNullary :: [Fn] -> [Fn]
 passRemoveBoxNullary fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (map removeBoxNullary blocks))) fns
 
 removeBoxNullary :: BasicBlock -> BasicBlock

--- a/src/Mir/Pass/RemoveBoxNullary.hs
+++ b/src/Mir/Pass/RemoveBoxNullary.hs
@@ -1,6 +1,18 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
+-----------------------------------------------------------------------
+-- |
+-- Module           : Mir.Pass.RemoveBoxNullary
+-- Description      : MIR Rewriting pass to remove nullary boxes
+-- Copyright        : (c) Galois, Inc 2017
+-- License          : BSD3
+-- Stability        : provisional
+--
+-- This module implements a MIR rewriting pass that eliminates all
+-- assignments of nullary box operations.  Such operations are necessarily
+-- NOPs and can be safely removed.
+-----------------------------------------------------------------------
 module Mir.Pass.RemoveBoxNullary
 ( passRemoveBoxNullary
 ) where
@@ -12,11 +24,10 @@ import qualified Data.Map.Strict as Map
 import Data.List
 
 import Mir.Mir
-import Mir.Pass
 
 import GHC.Stack
 
-passRemoveBoxNullary :: Pass
+passRemoveBoxNullary :: Collection -> Collection
 passRemoveBoxNullary fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (map removeBoxNullary blocks))) fns
 
 removeBoxNullary :: BasicBlock -> BasicBlock

--- a/src/Mir/Pass/RemoveBoxNullary.hs
+++ b/src/Mir/Pass/RemoveBoxNullary.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+module Mir.Pass.RemoveBoxNullary
+( passRemoveBoxNullary
+) where
+ 
+import Control.Lens hiding (op)
+import Control.Monad.State.Lazy
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import Data.List
+
+import Mir.Mir
+import Mir.Pass
+
+import GHC.Stack
+
+passRemoveBoxNullary :: Pass
+passRemoveBoxNullary fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (map removeBoxNullary blocks))) fns
+
+removeBoxNullary :: BasicBlock -> BasicBlock
+removeBoxNullary (BasicBlock bbi (BasicBlockData stmts term)) =
+    let stmts' = filter (\stmt -> case stmt of
+                Assign _ (NullaryOp Box _) -> False
+                _ -> True) stmts
+    in BasicBlock bbi (BasicBlockData stmts' term)
+

--- a/src/Mir/Pass/RemoveStorage.hs
+++ b/src/Mir/Pass/RemoveStorage.hs
@@ -1,6 +1,18 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
+
+-----------------------------------------------------------------------
+-- |
+-- Module           : Mir.Pass.RemoveStorage
+-- Description      : Rewriting pass for removing Storage annotations
+-- Copyright        : (c) Galois, Inc 2017
+-- License          : BSD3
+-- Stability        : provisional
+--
+-- This module implements a MIR rewriting pass that eliminates calls
+-- to the `StorageLive` and `StorageDead` primtives.
+-----------------------------------------------------------------------
 module Mir.Pass.RemoveStorage
 ( passRemoveStorage
 ) where
@@ -12,12 +24,11 @@ import qualified Data.Map.Strict as Map
 import Data.List
 
 import Mir.Mir
-import Mir.Pass
 
 import GHC.Stack
 
 -- remove storageDead / storageAlive calls
-passRemoveStorage :: Pass
+passRemoveStorage :: Collection -> Collection
 passRemoveStorage fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (prs_ blocks))) fns
 
 prs_ :: [BasicBlock] -> [BasicBlock]

--- a/src/Mir/Pass/RemoveStorage.hs
+++ b/src/Mir/Pass/RemoveStorage.hs
@@ -28,7 +28,7 @@ import Mir.Mir
 import GHC.Stack
 
 -- remove storageDead / storageAlive calls
-passRemoveStorage :: Collection -> Collection
+passRemoveStorage :: [Fn] -> [Fn]
 passRemoveStorage fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (prs_ blocks))) fns
 
 prs_ :: [BasicBlock] -> [BasicBlock]

--- a/src/Mir/Pass/RemoveStorage.hs
+++ b/src/Mir/Pass/RemoveStorage.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+module Mir.Pass.RemoveStorage
+( passRemoveStorage
+) where
+ 
+import Control.Lens hiding (op)
+import Control.Monad.State.Lazy
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import Data.List
+
+import Mir.Mir
+import Mir.Pass
+
+import GHC.Stack
+
+-- remove storageDead / storageAlive calls
+passRemoveStorage :: Pass
+passRemoveStorage fns = map (\(Fn a b c (MirBody d blocks)) -> Fn a b c (MirBody d (prs_ blocks))) fns
+
+prs_ :: [BasicBlock] -> [BasicBlock]
+prs_ bbs = map prs bbs
+
+prs :: BasicBlock -> BasicBlock
+prs (BasicBlock bbi (BasicBlockData stmts t)) =
+    let ns = filter (\stmt -> case stmt of
+                    StorageLive _ -> False
+                    StorageDead _ -> False
+                    _ -> True) stmts in
+    (BasicBlock bbi (BasicBlockData ns t))

--- a/src/Mir/Pass/RewriteMutRef.hs
+++ b/src/Mir/Pass/RewriteMutRef.hs
@@ -1,0 +1,315 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+module Mir.Pass.RewriteMutRef
+( passMutRefArgs
+) where
+ 
+import Control.Lens hiding (op)
+import Control.Monad.State.Lazy
+import qualified Data.Text as T
+import qualified Data.Map.Strict as Map
+import Data.List
+
+import Mir.Mir
+import Mir.Pass
+import Mir.Pass.CollapseRefs
+
+import GHC.Stack
+
+--other utils
+ints_list :: Int -> [Int]
+ints_list 0 = [0]
+ints_list i | i > 0 = (ints_list (i - 1)) ++ [i]
+            | i < 0 = error "bad intslist"
+
+
+modifyVarTy :: Var -> Ty -> Var
+modifyVarTy (Var a b c d) e = Var a b e d
+
+vars_to_map :: [Var] -> Map.Map T.Text Var
+vars_to_map vs = Map.fromList $ map (\v -> (_varname v, v)) vs
+
+mutref_to_immut :: Var -> Var
+mutref_to_immut (Var vn vm vty vsc) = Var (T.pack $ (T.unpack vn) ++ "d") vm (changeTyToImmut vty) vsc
+
+
+changeTyToImmut :: Ty -> Ty
+changeTyToImmut (TyRef c _) =  (TyRef c Immut)
+changeTyToImmut t = t
+
+passMutRefArgs :: HasCallStack => Pass
+passMutRefArgs = passRewriteMutRefArg . passCollapseRefs
+
+-- Pass for rewriting mutref args to be returned outside; i.e., if I
+-- have a function f(x : T1, y : &mut T2, z : T3, w : &mut T4) -> T5,
+-- it will be transformed into a function which returns (T5, T2,
+-- T4). All function calls are also transformed to handle this. This
+-- is done purely at the MIR "syntax" level.
+
+-- The algorithm is imperative -- everything is basically modified in place.
+
+data RewriteFnSt = RFS { --  state internal to function translation.
+    _fn_name :: T.Text,
+    _ctr :: Int, -- counter for fresh variables
+    _immut_arguments :: Map.Map T.Text Var, -- arguments to the function which don't need to be tampered with
+    -- vvv arguments of the form &mut T (or variations thereof.) The translation creates a dummy variable for each one. The dummy variable is the second. fst will end up in internals, snd will end up in arguments
+    _mut_argpairs :: Map.Map T.Text (Var, Var),
+    _ret_ty :: Ty,
+    _internals :: Map.Map T.Text Var, -- local variables
+    _blocks :: Map.Map T.Text BasicBlockData,
+    _dummyret :: Maybe Var, -- this is where the original return value goes, which will later be aggregated with the mutref values
+    _fnargsmap :: Map.Map T.Text [Ty], -- maps argument names to their types in the function signature
+    _fnsubstitutions :: Map.Map Lvalue Lvalue -- any substitutions which need to take place. all happen at the end
+    }
+
+fnSubstitutions :: Simple Lens RewriteFnSt (Map.Map Lvalue Lvalue)
+fnSubstitutions = lens _fnsubstitutions (\s v -> s { _fnsubstitutions = v })
+
+fnName :: Simple Lens (RewriteFnSt) T.Text
+fnName = lens _fn_name (\s v -> s { _fn_name = v })
+
+dummy_ctr :: Simple Lens (RewriteFnSt) Int
+dummy_ctr = lens _ctr (\s v -> s { _ctr = v })
+
+fnImmutArguments :: Simple Lens (RewriteFnSt) (Map.Map T.Text Var)
+fnImmutArguments = lens _immut_arguments (\s v -> s { _immut_arguments = v })
+
+fnArgsMap :: Simple Lens (RewriteFnSt) (Map.Map T.Text [Ty])
+fnArgsMap = lens _fnargsmap (\s v -> s { _fnargsmap = v })
+
+fnMutArgPairs :: Simple Lens (RewriteFnSt) (Map.Map T.Text (Var, Var))
+fnMutArgPairs = lens _mut_argpairs (\s v -> s { _mut_argpairs = v })
+
+fnDummyRet :: Simple Lens RewriteFnSt (Maybe Var)
+fnDummyRet = lens _dummyret (\s v -> s { _dummyret = v})
+
+fnRet_ty :: Simple Lens (RewriteFnSt) Ty
+fnRet_ty = lens _ret_ty (\s v -> s { _ret_ty = v })
+
+fnInternals :: Simple Lens (RewriteFnSt) (Map.Map T.Text Var)
+fnInternals = lens _internals (\s v -> s { _internals = v })
+
+fnBlocks :: Simple Lens (RewriteFnSt) (Map.Map T.Text BasicBlockData)
+fnBlocks = lens _blocks (\s v -> s { _blocks = v })
+
+newCtr :: State RewriteFnSt Int
+newCtr = do
+    c <- use dummy_ctr
+    dummy_ctr .= (c + 1)
+    return (c + 1)
+
+newDummyBlock :: T.Text -> BasicBlockData -> State RewriteFnSt BasicBlock
+newDummyBlock prev_name bbd = do
+    blocks <- use fnBlocks
+    let name = T.pack $ (T.unpack prev_name) ++ "d"
+    fnBlocks .= Map.insert name bbd blocks
+    return (BasicBlock name bbd)
+
+mkDummyInternal :: Ty -> State RewriteFnSt Var
+mkDummyInternal ty = do
+    internals <- use fnInternals
+    let dummyvar = (Var "_dummyret" Immut ty "scopedum")
+    fnInternals .= Map.insert "_dummyret" dummyvar internals
+    return dummyvar
+
+newInternal :: Ty -> State RewriteFnSt Var
+newInternal ty = do
+    ctr <- newCtr
+    let new_name = T.pack $ "_vd" ++ (show ctr)
+        new_var =  (Var new_name Immut ty "scopedum")
+    internals <- use fnInternals
+    fnInternals .= Map.insert new_name new_var internals
+    return new_var
+
+-- buildRewriteSt
+-- build initial rewrite state
+
+buildRewriteSt :: Fn -> [Fn] -> RewriteFnSt
+buildRewriteSt (Fn fname fargs fretty (MirBody internals blocks)) fns =
+    let (mut_args, immut_args) = partition (isMutRefTy . typeOf) fargs
+        immut_map = vars_to_map immut_args
+        mutpairmap = Map.map (\v -> (v, mutref_to_immut v)) (vars_to_map mut_args)
+        fnmap = Map.fromList $ map (\(Fn fn fa _ _) -> (fn, map typeOf fa)) fns in
+    RFS fname 0 immut_map mutpairmap fretty (vars_to_map internals) (Map.fromList $ map (\bb -> (_bbinfo bb, _bbdata bb)) blocks) Nothing fnmap Map.empty
+
+-- insertMutvarsIntoInternals
+-- put all x's into internals, where (x,y) are the mutarg pairs (x is old mut, y is new immut dummy)
+
+insertMutvarsIntoInternals :: State RewriteFnSt ()
+insertMutvarsIntoInternals = do
+    mutargpairs <- use fnMutArgPairs
+    forM_ (Map.toList mutargpairs) $ \(vname, (vmut, vimmut)) -> do
+        internals <- use fnInternals
+        fnInternals .= Map.insert vname vmut internals
+
+-- modifyAssignEntryBlock
+-- insert statements x := y where x is mut ref arg (will be internal), y is corresponding dummy into first block
+modifyAssignEntryBlock :: State RewriteFnSt ()
+modifyAssignEntryBlock = do
+    blocks <- use fnBlocks
+    mutpairs <- use fnMutArgPairs
+    let (BasicBlockData entry_stmts ei) = case Map.lookup (T.pack "bb0") blocks of
+                        Just b -> b
+                        Nothing -> error "entry block not found"
+
+        new_asgns = Map.elems $ Map.map (\(vmut, vimmut) -> Assign (Local vmut) (Use $ Consume $ Local vimmut)) mutpairs
+        new_bbd = BasicBlockData (new_asgns ++ entry_stmts) ei
+    fnBlocks .= Map.insert (T.pack "bb0") new_bbd blocks
+
+-- modifyRetData
+-- new fretty = (old fretty, x_1, .., x_n) where x_i are mutref types
+-- make _0 be new fretty
+-- make _dummyret be old fretty
+-- replace _0 with _dummyret in blocks
+
+modifyRetData :: State RewriteFnSt ()
+modifyRetData = do
+    old_fretty <- use fnRet_ty
+    mutpairs <- use fnMutArgPairs
+    internals <- use fnInternals
+    let new_fretty = TyTuple $ [old_fretty] ++ (map (_varty . snd) (Map.elems mutpairs))
+    fnRet_ty .= new_fretty
+
+    let (Just retvar) =  Map.lookup "_0" internals
+    fnInternals .= Map.insert "_0" (modifyVarTy retvar new_fretty) internals
+
+    dummy_ret <- mkDummyInternal old_fretty
+    fnDummyRet .= Just (dummy_ret)
+
+    blocks <- use fnBlocks
+    fnBlocks .= replaceVar retvar dummy_ret blocks
+
+-- make statement _0 := (_dummyret, x_1, x_2, ..) where x_i are internalized mutable argument
+mkPreReturnAssgn :: State RewriteFnSt Statement
+mkPreReturnAssgn = do
+    mutpairs <- use fnMutArgPairs
+    internals <- use fnInternals
+    let muts = Map.elems $ Map.map fst mutpairs
+    Just dummyret <- use fnDummyRet
+    let (Just retvar) = Map.lookup "_0" internals
+    return $ Assign (Local retvar) (Aggregate AKTuple $  [Consume (Local dummyret)] ++ (map (Consume . Local) muts))
+
+processReturnBlock_ :: BasicBlockData -> State RewriteFnSt BasicBlockData
+processReturnBlock_ (BasicBlockData stmts Return) = do
+    snew <- mkPreReturnAssgn
+    return (BasicBlockData (stmts ++ [snew]) Return)
+
+processReturnBlock_ v = return v
+
+-- processReturnBlocks :
+    --  last statement before return becomes _0 := (_dummyret, x_1, x_2, ..) where x_i are the internalized mutable arguments
+processReturnBlocks :: State RewriteFnSt ()
+processReturnBlocks = do
+    blocks <- use fnBlocks
+    newblocks <- mapM processReturnBlock_ blocks
+    fnBlocks .= newblocks
+
+-- for the example above where f is taken from returning T5 to (T5, T2, T4), mkFnCallVars creates the dummy variable for receiving the (T5, T2, T4)-value, as well as the corresponding destructures.
+
+mkFnCallVars :: Lvalue -> [Ty] -> State RewriteFnSt (Var, (Lvalue, [Lvalue]))
+mkFnCallVars orig_dest mut_tys = do
+    let type_list = [typeOf orig_dest] ++ mut_tys
+        type_of_new = TyTuple type_list
+    v <- newInternal type_of_new
+    let destructures = zipWith (\ind ty -> LProjection (LvalueProjection (Local v) (PField ind ty))) (ints_list ((length type_list) - 1)) type_list
+    return (v, (head destructures, tail destructures))
+
+    --  for each function call:
+    --     Call(f, args, (ret_lv, dest)) ->
+    --      v := newVar (mkCorrespondingTuple args ret_lv) -- mkCorrespondingTuple args ret_lv = (lv_type, (mut args tupl))
+    --      call(f, args, (Local v, B))
+    --      where B := newDummyBlock $
+    --          destructure v to (orig_return, (mutargs_changed))
+    --          assign ret_lv to orig_return
+    --          assign args to mutargs_changed
+    --          jump to dest
+processFnCall_ :: HasCallStack => BasicBlockInfo -> BasicBlockData -> State RewriteFnSt ()
+processFnCall_ bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean))
+    | Just _ <- isCustomFunc (funcNameofOp cfunc) = processCustomFnCall bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean))
+    | otherwise = do
+        fnargsmap <- use fnArgsMap
+        let (mut_cargs, immut_cargs) = sort_mutrefs cargs fnargsmap (funcNameofOp cfunc)
+        if (null mut_cargs) then do
+            return ()
+        else do
+            do_mutrefarg_trans bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean)) mut_cargs
+
+   where sort_mutrefs :: [Operand] -> Map.Map T.Text [Ty] -> T.Text -> ([Operand], [Operand])
+         sort_mutrefs args fnmap fname = case Map.lookup fname fnmap of
+                                           Just tys -> go args tys
+                                           Nothing -> error $ "fn not found: " ++ (show fname)
+
+         go :: [Operand] -> [Ty] -> ([Operand], [Operand])
+         go [] [] = ([], [])
+         go (o:os) (t:ts) = case (isMutRefTy t) of
+                              True -> let (a,b) = go os ts in (o:a, b)
+                              False -> let (a,b) = go os ts in (a, o:b)
+
+         processCustomFnCall :: HasCallStack => BasicBlockInfo -> BasicBlockData -> State RewriteFnSt ()
+         processCustomFnCall bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean))
+          | Just "vec_asmutslice" <- isCustomFunc (funcNameofOp cfunc),
+          [op] <- cargs = do -- collapse return var into input.
+              fnsubs <- use fnSubstitutions
+              fnSubstitutions .= Map.insert dest_lv (lValueofOp op) fnsubs
+          | Just "iter_next" <- isCustomFunc (funcNameofOp cfunc), [op] <- cargs = do -- op acts like a mutref.
+            do_mutrefarg_trans bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean)) [op]
+
+          | otherwise = return ()
+
+         do_mutrefarg_trans :: HasCallStack => BasicBlockInfo -> BasicBlockData -> [Operand] -> State RewriteFnSt ()
+         do_mutrefarg_trans bbi (BasicBlockData stmts (Call cfunc cargs (Just (dest_lv, dest_block)) cclean)) mut_cargs = do
+            (v, (v0, vrest)) <- mkFnCallVars dest_lv $ map typeOf mut_cargs
+            newb <- newDummyBlock bbi $ BasicBlockData
+                ([Assign dest_lv (Use $ Consume v0)] ++ (zipWith (\c v -> Assign (lValueofOp c) (Use $ Consume v)) mut_cargs vrest))
+                (Goto dest_block)
+
+            blocks <- use fnBlocks
+            fnBlocks .= Map.insert bbi (BasicBlockData stmts (Call cfunc cargs (Just (Local v, _bbinfo newb)) cclean)) blocks
+processFnCall_ _ _ = return ()
+
+processFnCalls :: HasCallStack => State RewriteFnSt ()
+processFnCalls = do
+    blocks <- use fnBlocks
+    forM_ (Map.toList blocks) $ \(k,v) -> do
+        processFnCall_ k v
+
+-- use the state to recover the transformed function
+extractFn :: HasCallStack => State RewriteFnSt Fn
+extractFn = do
+    immut_args <- use fnImmutArguments
+    mut_argpairs <- use fnMutArgPairs
+    ret_ty <- use fnRet_ty
+    internals <- use fnInternals
+    blocks <- use fnBlocks
+    fname <- use fnName
+    fsubs <- use fnSubstitutions
+
+    let blocks_ = replaceList (Map.toList fsubs) blocks
+
+    let fnargs = (Map.elems immut_args) ++ (Map.elems $ Map.map snd mut_argpairs)
+        fnblocks = map (\(k,v) -> BasicBlock k v) (Map.toList blocks_)
+    return $ Fn fname fnargs ret_ty (MirBody (Map.elems internals) fnblocks)
+
+
+-- if there are no mutref args, then the body of the function doesn't need to change
+needsToBeTransformed :: State RewriteFnSt Bool
+needsToBeTransformed = do
+    mutargpairs <- use fnMutArgPairs
+    return $ not $  Map.null mutargpairs
+
+rewriteMutRefArgFn :: HasCallStack => State RewriteFnSt Fn
+rewriteMutRefArgFn = do
+    b <- needsToBeTransformed
+    if b then do
+        modifyAssignEntryBlock
+        modifyRetData
+        processReturnBlocks
+        insertMutvarsIntoInternals
+    else do
+        return ()
+    processFnCalls
+    extractFn
+
+passRewriteMutRefArg :: HasCallStack => Pass
+passRewriteMutRefArg fns = map (\fn -> evalState (rewriteMutRefArgFn) (buildRewriteSt fn fns)) fns

--- a/src/Mir/Pass/RewriteMutRef.hs
+++ b/src/Mir/Pass/RewriteMutRef.hs
@@ -320,5 +320,5 @@ rewriteMutRefArgFn = do
     processFnCalls
     extractFn
 
-passRewriteMutRefArg :: HasCallStack => Collection -> Collection
+passRewriteMutRefArg :: HasCallStack => [Fn] -> [Fn]
 passRewriteMutRefArg fns = map (\fn -> evalState (rewriteMutRefArgFn) (buildRewriteSt fn fns)) fns

--- a/src/Mir/Run.hs
+++ b/src/Mir/Run.hs
@@ -137,7 +137,7 @@ extractFromCFGPure setup sc cfg = do
 
 
 handleAbortedResult :: C.AbortedResult sym -> String
-handleAbortedResult (C.AbortedExec simerror _) = C.simErrorReasonMsg $ C.simErrorReason simerror
+handleAbortedResult (C.AbortedExec simerror _) = show $ C.ppSimError simerror
 handleAbortedResult _ = "unknown"
 
 mirToCFG :: [M.Fn] -> Maybe ([M.Fn] -> [M.Fn]) -> Map.Map Text.Text C.AnyCFG

--- a/src/Mir/SAWInterface.hs
+++ b/src/Mir/SAWInterface.hs
@@ -66,7 +66,9 @@ loadMIR sc fp = do
     case c of
       Left msg -> fail $ "Decoding of MIR failed: " ++ msg
       Right coll -> do
-          mapM_ (putStrLn . pprint) coll
-          let cfgmap_ = mirToCFG coll (Just (P.passMutRefArgs . P.passRemoveStorage . P.passRemoveBoxNullary))
+          let passes = P.passMutRefArgs . P.passRemoveStorage . P.passRemoveBoxNullary
+          let coll' = passes coll
+          mapM_ (putStrLn . pprint) coll'
+          let cfgmap_ = mirToCFG coll Nothing
           let cfgmap = M.fromList $ map (\(k,v) -> (cleanFnName k, v)) $ M.toList cfgmap_
           return $ RustModule cfgmap

--- a/src/Mir/SAWInterface.hs
+++ b/src/Mir/SAWInterface.hs
@@ -66,9 +66,10 @@ loadMIR sc fp = do
     case c of
       Left msg -> fail $ "Decoding of MIR failed: " ++ msg
       Right coll -> do
-          let passes = P.passMutRefArgs . P.passRemoveStorage . P.passRemoveBoxNullary
+          --let passes = P.passMutRefArgs . P.passRemoveStorage . P.passRemoveBoxNullary
+          let passes = P.passRemoveBoxNullary
           let coll' = passes (functions coll)
           mapM_ (putStrLn . pprint) coll'
-          let cfgmap_ = mirToCFG coll Nothing
+          let cfgmap_ = mirToCFG coll' Nothing
           let cfgmap = M.fromList $ map (\(k,v) -> (cleanFnName k, v)) $ M.toList cfgmap_
           return $ RustModule cfgmap

--- a/src/Mir/SAWInterface.hs
+++ b/src/Mir/SAWInterface.hs
@@ -69,7 +69,7 @@ loadMIR sc fp = do
           --let passes = P.passMutRefArgs . P.passRemoveStorage . P.passRemoveBoxNullary
           let passes = P.passRemoveBoxNullary
           let coll' = passes (functions coll)
-          mapM_ (putStrLn . pprint) coll'
+          -- mapM_ (putStrLn . pprint) coll'
           let cfgmap_ = mirToCFG coll' Nothing
           let cfgmap = M.fromList $ map (\(k,v) -> (cleanFnName k, v)) $ M.toList cfgmap_
           return $ RustModule cfgmap

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -166,13 +166,13 @@ tyToRepr t = case t of
                M.TyBool -> Some CT.BoolRepr
                M.TyTuple ts ->  tyListToCtx ts $ \repr -> Some (CT.StructRepr repr)
                M.TyArray t _sz -> tyToReprCont t $ \repr -> Some (CT.VectorRepr repr)
-               M.TyInt M.USize -> Some $ CT.NatRepr
+               M.TyInt M.USize -> Some $ CT.NatRepr -- FIXME!
                M.TyInt M.B8 -> Some $ CT.BVRepr (knownNat :: NatRepr 8)
                M.TyInt M.B16 -> Some $ CT.BVRepr (knownNat :: NatRepr 16)
                M.TyInt M.B32 -> Some $ CT.BVRepr (knownNat :: NatRepr 32)
                M.TyInt M.B64 -> Some $ CT.BVRepr (knownNat :: NatRepr 64)
                M.TyInt M.B128 -> Some $ CT.BVRepr (knownNat :: NatRepr 128)
-               M.TyUint M.USize -> Some $ CT.NatRepr
+               M.TyUint M.USize -> Some $ CT.NatRepr -- FIXME!
                M.TyUint M.B8 -> Some $ CT.BVRepr (knownNat :: NatRepr 8)
                M.TyUint M.B16 -> Some $ CT.BVRepr (knownNat :: NatRepr 16)
                M.TyUint M.B32 -> Some $ CT.BVRepr (knownNat :: NatRepr 32)
@@ -186,7 +186,9 @@ tyToRepr t = case t of
                M.TyCustom custom_t -> customtyToRepr custom_t
                M.TyClosure def_id substs -> Some $ CT.AnyRepr
                M.TyStr -> Some $ CT.StringRepr
-               -- M.TyAdt a -> adtToRepr a
+               M.TyAdt _defid _tyargs -> Some $ taggedUnionType
+               M.TyFloat _ -> Some $ CT.RealValRepr
+               M.TyParam _ -> Some $ CT.AnyRepr -- FIXME??
                _ -> error $ unwords ["unknown type?", show t]
 
 -- As in the CPS translation, functions which manipulate types must be in CPS form, since type tags are generally hidden underneath an existential.
@@ -561,7 +563,7 @@ evalRval (M.Ref bk lv _) =
                  do r <- G.readReg reg
                     return $ MirExp (R.typeOfReg reg) r
                _ -> fail ("Mutable reference-taken variable not backed by reference! " <> show nm <> " at " <> Text.unpack pos)
-        _ -> fail "FIXME! evalRval, Ref for non-local lvars"
+        _ -> fail ("FIXME! evalRval, Ref for non-local lvars" ++ show lv)
     M.Unique  -> fail "FIXME! Unique reference not implemented"
 
 evalRval (M.Len lv) =


### PR DESCRIPTION
Rework much of the Crucible translation to handle mutable references and slices by using Crucible references instead of rewriting functions to take and then return values.

Also refactor the rewriting passes into separate modules and document their function as best I understand them.