### PR TITLE
add symbolic test to check correctness of `Scalar64::add`

### DIFF
--- a/src/Mir/Overrides.hs
+++ b/src/Mir/Overrides.hs
@@ -125,17 +125,17 @@ bindFn fn cfg =
                     liftIO (hPutStrLn h "Hello, I'm an override")
                     v <- liftIO $ bvLit (s :: sym) knownNat 1
                     return v
-               , symb_bv "::crucible_i8[0]"  (knownNat @ 8)
-               , symb_bv "::crucible_i16[0]" (knownNat @ 16)
-               , symb_bv "::crucible_i32[0]" (knownNat @ 32)
-               , symb_bv "::crucible_i64[0]" (knownNat @ 64)
-               , symb_bv "::crucible_u8[0]"  (knownNat @ 8)
-               , symb_bv "::crucible_u16[0]" (knownNat @ 16)
-               , symb_bv "::crucible_u32[0]" (knownNat @ 32)
-               , symb_bv "::crucible_u64[0]" (knownNat @ 64)
+               , symb_bv "::crucible[0]::crucible_i8[0]"  (knownNat @ 8)
+               , symb_bv "::crucible[0]::crucible_i16[0]" (knownNat @ 16)
+               , symb_bv "::crucible[0]::crucible_i32[0]" (knownNat @ 32)
+               , symb_bv "::crucible[0]::crucible_i64[0]" (knownNat @ 64)
+               , symb_bv "::crucible[0]::crucible_u8[0]"  (knownNat @ 8)
+               , symb_bv "::crucible[0]::crucible_u16[0]" (knownNat @ 16)
+               , symb_bv "::crucible[0]::crucible_u32[0]" (knownNat @ 32)
+               , symb_bv "::crucible[0]::crucible_u64[0]" (knownNat @ 64)
                , symb_bv "::int512[0]::symbolic[0]" (knownNat @ 512)
                , let argTys = (Empty :> BoolRepr :> strrepr :> strrepr :> u32repr :> u32repr)
-                 in override "::crucible_assert_impl[0]" argTys UnitRepr $
+                 in override "::crucible[0]::crucible_assert_impl[0]" argTys UnitRepr $
                     do RegMap (Empty :> c :> srcArg :> fileArg :> lineArg :> colArg) <- getOverrideArgs
                        s <- getSymInterface
                        src <- maybe (fail "not a constant src string")
@@ -149,7 +149,7 @@ bindFn fn cfg =
                        liftIO $ assert s (regValue c) reason
                        return ()
                , let argTys = (Empty :> BoolRepr :> strrepr :> strrepr :> u32repr :> u32repr)
-                 in override "::crucible_assume_impl[0]" argTys UnitRepr $
+                 in override "::crucible[0]::crucible_assume_impl[0]" argTys UnitRepr $
                     do RegMap (Empty :> c :> srcArg :> fileArg :> lineArg :> colArg) <- getOverrideArgs
                        s <- getSymInterface
                        loc <- liftIO $ getCurrentProgramLoc s

--- a/test/symb_eval/scalar/constants.rs
+++ b/test/symb_eval/scalar/constants.rs
@@ -1,0 +1,132 @@
+// -*- mode: rust; -*-
+//
+// This file is part of curve25519-dalek.
+// Copyright (c) 2016-2018 Isis Lovecruft, Henry de Valence
+// See LICENSE for licensing information.
+//
+// Authors:
+// - Isis Agora Lovecruft <isis@patternsinthevoid.net>
+// - Henry de Valence <hdevalence@hdevalence.ca>
+
+//! This module contains backend-specific constant values, such as the 64-bit limbs of curve constants.
+
+//use backend::serial::u64::field::FieldElement51;
+//use backend::serial::u64::scalar::Scalar52;
+//use edwards::EdwardsPoint;
+use scalar::Scalar52;
+
+/// Edwards `d` value, equal to `-121665/121666 mod p`.
+#[cfg(off)] pub(crate) const EDWARDS_D: FieldElement51 = FieldElement51([929955233495203, 466365720129213, 1662059464998953, 2033849074728123, 1442794654840575]);
+
+/// Edwards `2*d` value, equal to `2*(-121665/121666) mod p`.
+#[cfg(off)] pub(crate) const EDWARDS_D2: FieldElement51 = FieldElement51([1859910466990425, 932731440258426, 1072319116312658, 1815898335770999, 633789495995903]);
+
+/// `= sqrt(a*d - 1)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.
+#[cfg(off)] pub(crate) const SQRT_AD_MINUS_ONE: FieldElement51 = FieldElement51([
+    2241493124984347, 425987919032274, 2207028919301688, 1220490630685848, 974799131293748
+]);
+
+/// `= 1/sqrt(a-d)`, where `a = -1 (mod p)`, `d` are the Edwards curve parameters.
+#[cfg(off)] pub(crate) const INVSQRT_A_MINUS_D: FieldElement51 = FieldElement51([
+    278908739862762, 821645201101625, 8113234426968, 1777959178193151, 2118520810568447
+]);
+
+/// Precomputed value of one of the square roots of -1 (mod p)
+#[cfg(off)] pub(crate) const SQRT_M1: FieldElement51 = FieldElement51([1718705420411056, 234908883556509, 2233514472574048, 2117202627021982, 765476049583133]);
+
+/// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
+#[cfg(off)] pub(crate) const APLUS2_OVER_FOUR: FieldElement51 = FieldElement51([121666, 0, 0, 0, 0]);
+
+/// `L` is the order of base point, i.e. 2^252 + 27742317777372353535851937790883648493
+pub(crate) const L: Scalar52 = Scalar52([ 0x0002631a5cf5d3ed, 0x000dea2f79cd6581, 0x000000000014def9, 0x0000000000000000, 0x0000100000000000 ]);
+
+/// `L` * `LFACTOR` = -1 (mod 2^52)
+pub(crate) const LFACTOR: u64 = 0x51da312547e1b;
+
+/// `R` = R % L where R = 2^260
+pub(crate) const R: Scalar52 = Scalar52([ 0x000f48bd6721e6ed, 0x0003bab5ac67e45a, 0x000fffffeb35e51b, 0x000fffffffffffff, 0x00000fffffffffff ]);
+
+/// `RR` = (R^2) % L where R = 2^260
+pub(crate) const RR: Scalar52 = Scalar52([ 0x0009d265e952d13b, 0x000d63c715bea69f, 0x0005be65cb687604, 0x0003dceec73d217f, 0x000009411b7c309a ]);
+
+/// The Ed25519 basepoint, as an `EdwardsPoint`.
+///
+/// This is called `_POINT` to distinguish it from
+/// `ED25519_BASEPOINT_TABLE`, which should be used for scalar
+/// multiplication (it's much faster).
+#[cfg(off)] pub const ED25519_BASEPOINT_POINT: EdwardsPoint = EdwardsPoint{
+    X: FieldElement51([1738742601995546, 1146398526822698, 2070867633025821, 562264141797630, 587772402128613]),
+    Y: FieldElement51([1801439850948184, 1351079888211148, 450359962737049, 900719925474099, 1801439850948198]),
+    Z: FieldElement51([1, 0, 0, 0, 0]),
+    T: FieldElement51([1841354044333475, 16398895984059, 755974180946558, 900171276175154, 1821297809914039]),
+};
+
+/// The 8-torsion subgroup \\(\mathcal E [8]\\).
+///
+/// In the case of Curve25519, it is cyclic; the \\(i\\)-th element of
+/// the array is \\([i]P\\), where \\(P\\) is a point of order \\(8\\)
+/// generating \\(\mathcal E[8]\\).
+///
+/// Thus \\(\mathcal E[4]\\) is the points indexed by `0,2,4,6`, and
+/// \\(\mathcal E[2]\\) is the points indexed by `0,4`.
+#[cfg(off)] pub const EIGHT_TORSION: [EdwardsPoint; 8] = EIGHT_TORSION_INNER_DOC_HIDDEN;
+
+/// Inner item used to hide limb constants from cargo doc output.
+#[doc(hidden)]
+#[cfg(off)] pub const EIGHT_TORSION_INNER_DOC_HIDDEN: [EdwardsPoint; 8] = [
+    EdwardsPoint {
+        X: FieldElement51([0, 0, 0, 0, 0]),
+        Y: FieldElement51([1, 0, 0, 0, 0]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([0, 0, 0, 0, 0]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([358744748052810, 1691584618240980, 977650209285361, 1429865912637724, 560044844278676]),
+        Y: FieldElement51([84926274344903, 473620666599931, 365590438845504, 1028470286882429, 2146499180330972]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([1448326834587521, 1857896831960481, 1093722731865333, 1677408490711241, 1915505153018406]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([533094393274173, 2016890930128738, 18285341111199, 134597186663265, 1486323764102114]),
+        Y: FieldElement51([0, 0, 0, 0, 0]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([0, 0, 0, 0, 0]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([358744748052810, 1691584618240980, 977650209285361, 1429865912637724, 560044844278676]),
+        Y: FieldElement51([2166873539340326, 1778179147085316, 1886209374839743, 1223329526802818, 105300633354275]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([803472979097708, 393902981724766, 1158077081819914, 574391322974006, 336294660666841]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([0, 0, 0, 0, 0]),
+        Y: FieldElement51([2251799813685228, 2251799813685247, 2251799813685247, 2251799813685247, 2251799813685247]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([0, 0, 0, 0, 0]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([1893055065632419, 560215195444267, 1274149604399886, 821933901047523, 1691754969406571]),
+        Y: FieldElement51([2166873539340326, 1778179147085316, 1886209374839743, 1223329526802818, 105300633354275]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([1448326834587521, 1857896831960481, 1093722731865333, 1677408490711241, 1915505153018406]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([1718705420411056, 234908883556509, 2233514472574048, 2117202627021982, 765476049583133]),
+        Y: FieldElement51([0, 0, 0, 0, 0]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([0, 0, 0, 0, 0]),
+    }
+    ,
+    EdwardsPoint {
+        X: FieldElement51([1893055065632419, 560215195444267, 1274149604399886, 821933901047523, 1691754969406571]),
+        Y: FieldElement51([84926274344903, 473620666599931, 365590438845504, 1028470286882429, 2146499180330972]),
+        Z: FieldElement51([1, 0, 0, 0, 0]),
+        T: FieldElement51([803472979097708, 393902981724766, 1158077081819914, 574391322974006, 336294660666841]),
+    }
+];

--- a/test/symb_eval/scalar/crucible.rs
+++ b/test/symb_eval/scalar/crucible.rs
@@ -1,0 +1,54 @@
+pub fn crucible_u64(_x: &'static str) -> u64 { unimplemented!() }
+
+macro_rules! crucible_scalar64 {
+    ($desc:expr) => {
+        Scalar52([
+            $crate::crucible::crucible_u64(concat!($desc, "_0")),
+            $crate::crucible::crucible_u64(concat!($desc, "_1")),
+            $crate::crucible::crucible_u64(concat!($desc, "_2")),
+            $crate::crucible::crucible_u64(concat!($desc, "_3")),
+            $crate::crucible::crucible_u64(concat!($desc, "_4")),
+        ])
+    };
+}
+
+#[allow(unused_variables)]
+pub fn crucible_assert_impl(
+    cond: bool,
+    cond_str: &'static str,
+    file: &'static str,
+    line: u32,
+    col: u32,
+) -> () {
+    ()
+}
+
+#[allow(unused_variables)]
+pub fn crucible_assume_impl(
+    cond: bool,
+    cond_str: &'static str,
+    file: &'static str,
+    line: u32,
+    col: u32,
+) -> () {
+    ()
+}
+
+macro_rules! crucible_assert {
+    ($e:expr) => {
+        $crate::crucible::crucible_assert_impl($e, stringify!($e), file!(), line!(), column!())
+    };
+}
+
+macro_rules! crucible_assume {
+    ($e:expr) => {
+        $crate::crucible::crucible_assume_impl($e, stringify!($e), file!(), line!(), column!())
+    };
+}
+
+macro_rules! crucible_debug_integer {
+    ($e:expr) => { crucible_debug_integer!($e, stringify!($e)) };
+    ($e:expr, $desc:expr) => {
+        crucible_assume!($e == $crate::int512::Int512::symbolic($desc))
+    };
+}

--- a/test/symb_eval/scalar/int512.rs
+++ b/test/symb_eval/scalar/int512.rs
@@ -1,0 +1,106 @@
+use core::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr};
+use core::cmp::{Ord, PartialOrd, Ordering};
+
+#[derive(Copy)]
+pub struct Int512 {}
+
+pub fn clone(_i: &Int512) -> Int512 { unimplemented!() }
+impl Clone for Int512 {
+    fn clone(&self) -> Int512 { clone(self) }
+}
+
+pub fn symbolic(_x: &'static str) -> Int512 { unimplemented!() }
+impl Int512 {
+    pub fn symbolic(x: &'static str) -> Int512 { symbolic(x) }
+}
+
+macro_rules! binop {
+    ($Op:ident, $op:ident) => {
+        pub fn $op(_x: Int512, _y: Int512) -> Int512 { unimplemented!() }
+
+        impl Int512 {
+            pub fn $op(self, other: Int512) -> Int512 { $op(self, other) }
+        }
+
+        impl $Op<Int512> for Int512 {
+            type Output = Int512;
+            fn $op(self, other: Int512) -> Int512 { $op(self, other) }
+        }
+    };
+}
+binop!(Add, add);
+binop!(Sub, sub);
+binop!(Mul, mul);
+binop!(Div, div);
+binop!(Rem, rem);
+binop!(BitAnd, bitand);
+binop!(BitOr, bitor);
+binop!(BitXor, bitxor);
+
+macro_rules! shift_op {
+    ($Op:ident, $op:ident) => {
+        pub fn $op(_x: Int512, _bits: u32) -> Int512 { unimplemented!() }
+
+        impl Int512 {
+            pub fn $op(self, bits: u32) -> Int512 { $op(self, bits) }
+        }
+
+        impl $Op<u32> for Int512 {
+            type Output = Int512;
+            fn $op(self, bits: u32) -> Int512 { $op(self, bits) }
+        }
+    };
+}
+shift_op!(Shl, shl);
+shift_op!(Shr, shr);
+
+pub fn eq(_x: Int512, _y: Int512) -> bool { unimplemented!() }
+impl PartialEq for Int512 {
+    fn eq(&self, other: &Int512) -> bool { eq(*self, *other) }
+    fn ne(&self, other: &Int512) -> bool { !eq(*self, *other) }
+}
+impl Eq for Int512 {}
+
+pub fn lt(_x: Int512, _y: Int512) -> bool { unimplemented!() }
+impl PartialOrd for Int512 {
+    fn partial_cmp(&self, other: &Int512) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for Int512 {
+    fn cmp(&self, other: &Int512) -> Ordering {
+        if eq(*self, *other) { Ordering::Equal }
+        else if lt(*self, *other) { Ordering::Less }
+        else { Ordering::Greater }
+    }
+}
+
+macro_rules! prim_cast {
+    ($Prim:ident) => {
+        pub mod $Prim {
+            use super::Int512;
+            pub fn from_prim(_x: $Prim) -> Int512 { unimplemented!() }
+            pub fn as_prim(_x: Int512) -> $Prim { unimplemented!() }
+        }
+
+        impl From<$Prim> for Int512 {
+            fn from(x: $Prim) -> Int512 { self::$Prim::from_prim(x) }
+        }
+
+        impl From<Int512> for $Prim {
+            fn from(x: Int512) -> $Prim { self::$Prim::as_prim(x) }
+        }
+    };
+}
+prim_cast!(u8);
+prim_cast!(u16);
+prim_cast!(u32);
+prim_cast!(u64);
+prim_cast!(u128);
+prim_cast!(usize);
+prim_cast!(i8);
+prim_cast!(i16);
+prim_cast!(i32);
+prim_cast!(i64);
+prim_cast!(i128);
+prim_cast!(isize);

--- a/test/symb_eval/scalar/scalar.rs
+++ b/test/symb_eval/scalar/scalar.rs
@@ -1,0 +1,443 @@
+//! Arithmetic mod \\(2\^{252} + 27742317777372353535851937790883648493\\)
+//! with five \\(52\\)-bit unsigned limbs.
+//!
+//! \\(51\\)-bit limbs would cover the desired bit range (\\(253\\)
+//! bits), but isn't large enough to reduce a \\(512\\)-bit number with
+//! Montgomery multiplication, so \\(52\\) bits is used instead.  To see
+//! that this is safe for intermediate results, note that the largest
+//! limb in a \\(5\times 5\\) product of \\(52\\)-bit limbs will be
+//!
+//! ```text
+//! (0xfffffffffffff^2) * 5 = 0x4ffffffffffff60000000000005 (107 bits).
+//! ```
+
+//use core::fmt::Debug;
+use core::ops::{Index, IndexMut};
+
+use constants;
+
+/// The `Scalar52` struct represents an element in
+/// \\(\mathbb Z / \ell \mathbb Z\\) as 5 \\(52\\)-bit limbs.
+#[derive(Copy,Clone)]
+pub struct Scalar52(pub [u64; 5]);
+
+//impl Debug for Scalar52 {
+//    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+//        write!(f, "Scalar52: {:?}", &self.0[..])
+//    }
+//}
+
+impl Index<usize> for Scalar52 {
+    type Output = u64;
+    fn index(&self, _index: usize) -> &u64 {
+        &(self.0[_index])
+    }
+}
+
+impl IndexMut<usize> for Scalar52 {
+    fn index_mut(&mut self, _index: usize) -> &mut u64 {
+        &mut (self.0[_index])
+    }
+}
+
+/// u64 * u64 = u128 multiply helper
+#[inline(always)]
+fn m(x: u64, y: u64) -> u128 {
+    (x as u128) * (y as u128)
+}
+
+impl Scalar52 {
+    /// Return the zero scalar
+    pub fn zero() -> Scalar52 {
+        Scalar52([0,0,0,0,0])
+    }
+
+    /// Unpack a 32 byte / 256 bit scalar into 5 52-bit limbs.
+    pub fn from_bytes(bytes: &[u8; 32]) -> Scalar52 {
+        let mut words = [0u64; 4];
+        for i in 0..4 {
+            for j in 0..8 {
+                words[i] |= (bytes[(i * 8) + j] as u64) << (j * 8);
+            }
+        }
+
+        let mask = (1u64 << 52) - 1;
+        let top_mask = (1u64 << 48) - 1;
+        let mut s = Scalar52::zero();
+
+        s[ 0] =   words[0]                            & mask;
+        s[ 1] = ((words[0] >> 52) | (words[1] << 12)) & mask;
+        s[ 2] = ((words[1] >> 40) | (words[2] << 24)) & mask;
+        s[ 3] = ((words[2] >> 28) | (words[3] << 36)) & mask;
+        s[ 4] =  (words[3] >> 16)                     & top_mask;
+
+        s
+    }
+
+    /// Reduce a 64 byte / 512 bit scalar mod l
+    pub fn from_bytes_wide(bytes: &[u8; 64]) -> Scalar52 {
+        let mut words = [0u64; 8];
+        for i in 0..8 {
+            for j in 0..8 {
+                words[i] |= (bytes[(i * 8) + j] as u64) << (j * 8);
+            }
+        }
+
+        let mask = (1u64 << 52) - 1;
+        let mut lo = Scalar52::zero();
+        let mut hi = Scalar52::zero();
+
+        lo[0] =   words[ 0]                             & mask;
+        lo[1] = ((words[ 0] >> 52) | (words[ 1] << 12)) & mask;
+        lo[2] = ((words[ 1] >> 40) | (words[ 2] << 24)) & mask;
+        lo[3] = ((words[ 2] >> 28) | (words[ 3] << 36)) & mask;
+        lo[4] = ((words[ 3] >> 16) | (words[ 4] << 48)) & mask;
+        hi[0] =  (words[ 4] >>  4)                      & mask;
+        hi[1] = ((words[ 4] >> 56) | (words[ 5] <<  8)) & mask;
+        hi[2] = ((words[ 5] >> 44) | (words[ 6] << 20)) & mask;
+        hi[3] = ((words[ 6] >> 32) | (words[ 7] << 32)) & mask;
+        hi[4] =   words[ 7] >> 20                             ;
+
+        lo = Scalar52::montgomery_mul(&lo, &constants::R);  // (lo * R) / R = lo
+        hi = Scalar52::montgomery_mul(&hi, &constants::RR); // (hi * R^2) / R = hi * R
+
+        Scalar52::add(&hi, &lo)
+    }
+
+    /// Pack the limbs of this `Scalar52` into 32 bytes
+    pub fn to_bytes(&self) -> [u8; 32] {
+        let mut s = [0u8; 32];
+
+        s[0]  =  (self.0[ 0] >>  0)                      as u8;
+        s[1]  =  (self.0[ 0] >>  8)                      as u8;
+        s[2]  =  (self.0[ 0] >> 16)                      as u8;
+        s[3]  =  (self.0[ 0] >> 24)                      as u8;
+        s[4]  =  (self.0[ 0] >> 32)                      as u8;
+        s[5]  =  (self.0[ 0] >> 40)                      as u8;
+        s[6]  = ((self.0[ 0] >> 48) | (self.0[ 1] << 4)) as u8;
+        s[7]  =  (self.0[ 1] >>  4)                      as u8;
+        s[8]  =  (self.0[ 1] >> 12)                      as u8;
+        s[9]  =  (self.0[ 1] >> 20)                      as u8;
+        s[10] =  (self.0[ 1] >> 28)                      as u8;
+        s[11] =  (self.0[ 1] >> 36)                      as u8;
+        s[12] =  (self.0[ 1] >> 44)                      as u8;
+        s[13] =  (self.0[ 2] >>  0)                      as u8;
+        s[14] =  (self.0[ 2] >>  8)                      as u8;
+        s[15] =  (self.0[ 2] >> 16)                      as u8;
+        s[16] =  (self.0[ 2] >> 24)                      as u8;
+        s[17] =  (self.0[ 2] >> 32)                      as u8;
+        s[18] =  (self.0[ 2] >> 40)                      as u8;
+        s[19] = ((self.0[ 2] >> 48) | (self.0[ 3] << 4)) as u8;
+        s[20] =  (self.0[ 3] >>  4)                      as u8;
+        s[21] =  (self.0[ 3] >> 12)                      as u8;
+        s[22] =  (self.0[ 3] >> 20)                      as u8;
+        s[23] =  (self.0[ 3] >> 28)                      as u8;
+        s[24] =  (self.0[ 3] >> 36)                      as u8;
+        s[25] =  (self.0[ 3] >> 44)                      as u8;
+        s[26] =  (self.0[ 4] >>  0)                      as u8;
+        s[27] =  (self.0[ 4] >>  8)                      as u8;
+        s[28] =  (self.0[ 4] >> 16)                      as u8;
+        s[29] =  (self.0[ 4] >> 24)                      as u8;
+        s[30] =  (self.0[ 4] >> 32)                      as u8;
+        s[31] =  (self.0[ 4] >> 40)                      as u8;
+
+        s
+    }
+
+    /// Compute `a + b` (mod l)
+    pub fn add(a: &Scalar52, b: &Scalar52) -> Scalar52 {
+        let mut sum = Scalar52::zero();
+        let mask = (1u64 << 52) - 1;
+
+        // a + b
+        let mut carry: u64 = 0;
+        for i in 0..5 {
+            carry = a[i] + b[i] + (carry >> 52);
+            sum[i] = carry & mask;
+        }
+
+        // subtract l if the sum is >= l
+        Scalar52::sub(&sum, &constants::L)
+    }
+
+    /// Compute `a - b` (mod l)
+    pub fn sub(a: &Scalar52, b: &Scalar52) -> Scalar52 {
+        let mut difference = Scalar52::zero();
+        let mask = (1u64 << 52) - 1;
+
+        // a - b
+        let mut borrow: u64 = 0;
+        for i in 0..5 {
+            borrow = a[i].wrapping_sub(b[i] + (borrow >> 63));
+            difference[i] = borrow & mask;
+        }
+
+        // conditionally add l if the difference is negative
+        let underflow_mask = ((borrow >> 63) ^ 1).wrapping_sub(1);
+        let mut carry: u64 = 0;
+        for i in 0..5 {
+            carry = (carry >> 52) + difference[i] + (constants::L[i] & underflow_mask);
+            difference[i] = carry & mask;
+        }
+
+        difference
+    }
+
+    /// Compute `a * b`
+    #[inline(always)]
+    pub (crate) fn mul_internal(a: &Scalar52, b: &Scalar52) -> [u128; 9] {
+        let mut z = [0u128; 9];
+
+        z[0] = m(a[0],b[0]);
+        z[1] = m(a[0],b[1]) + m(a[1],b[0]);
+        z[2] = m(a[0],b[2]) + m(a[1],b[1]) + m(a[2],b[0]);
+        z[3] = m(a[0],b[3]) + m(a[1],b[2]) + m(a[2],b[1]) + m(a[3],b[0]);
+        z[4] = m(a[0],b[4]) + m(a[1],b[3]) + m(a[2],b[2]) + m(a[3],b[1]) + m(a[4],b[0]);
+        z[5] =                m(a[1],b[4]) + m(a[2],b[3]) + m(a[3],b[2]) + m(a[4],b[1]);
+        z[6] =                               m(a[2],b[4]) + m(a[3],b[3]) + m(a[4],b[2]);
+        z[7] =                                              m(a[3],b[4]) + m(a[4],b[3]);
+        z[8] =                                                             m(a[4],b[4]);
+
+        z
+    }
+
+    /// Compute `a^2`
+    #[inline(always)]
+    fn square_internal(a: &Scalar52) -> [u128; 9] {
+        let aa = [
+            a[0]*2,
+            a[1]*2,
+            a[2]*2,
+            a[3]*2,
+        ];
+
+        [
+            m( a[0],a[0]),
+            m(aa[0],a[1]),
+            m(aa[0],a[2]) + m( a[1],a[1]),
+            m(aa[0],a[3]) + m(aa[1],a[2]),
+            m(aa[0],a[4]) + m(aa[1],a[3]) + m( a[2],a[2]),
+                            m(aa[1],a[4]) + m(aa[2],a[3]),
+                                            m(aa[2],a[4]) + m( a[3],a[3]),
+                                                            m(aa[3],a[4]),
+                                                                            m(a[4],a[4])
+        ]
+    }
+
+    /// Compute `limbs/R` (mod l), where R is the Montgomery modulus 2^260
+    #[inline(always)]
+    pub (crate) fn montgomery_reduce(limbs: &[u128; 9]) -> Scalar52 {
+
+        #[inline(always)]
+        fn part1(sum: u128) -> (u128, u64) {
+            let p = (sum as u64).wrapping_mul(constants::LFACTOR) & ((1u64 << 52) - 1);
+            ((sum + m(p,constants::L[0])) >> 52, p)
+        }
+
+        #[inline(always)]
+        fn part2(sum: u128) -> (u128, u64) {
+            let w = (sum as u64) & ((1u64 << 52) - 1);
+            (sum >> 52, w)
+        }
+
+        // note: l3 is zero, so its multiplies can be skipped
+        let l = &constants::L;
+
+        // the first half computes the Montgomery adjustment factor n, and begins adding n*l to make limbs divisible by R
+        let (carry, n0) = part1(        limbs[0]);
+        let (carry, n1) = part1(carry + limbs[1] + m(n0,l[1]));
+        let (carry, n2) = part1(carry + limbs[2] + m(n0,l[2]) + m(n1,l[1]));
+        let (carry, n3) = part1(carry + limbs[3]              + m(n1,l[2]) + m(n2,l[1]));
+        let (carry, n4) = part1(carry + limbs[4] + m(n0,l[4])              + m(n2,l[2]) + m(n3,l[1]));
+
+        // limbs is divisible by R now, so we can divide by R by simply storing the upper half as the result
+        let (carry, r0) = part2(carry + limbs[5]              + m(n1,l[4])              + m(n3,l[2]) + m(n4,l[1]));
+        let (carry, r1) = part2(carry + limbs[6]                           + m(n2,l[4])              + m(n4,l[2]));
+        let (carry, r2) = part2(carry + limbs[7]                                        + m(n3,l[4])             );
+        let (carry, r3) = part2(carry + limbs[8]                                                     + m(n4,l[4]));
+        let         r4 = carry as u64;
+
+        // result may be >= l, so attempt to subtract l
+        Scalar52::sub(&Scalar52([r0,r1,r2,r3,r4]), l)
+    }
+
+    /// Compute `a * b` (mod l)
+    #[inline(never)]
+    pub fn mul(a: &Scalar52, b: &Scalar52) -> Scalar52 {
+        let ab = Scalar52::montgomery_reduce(&Scalar52::mul_internal(a, b));
+        Scalar52::montgomery_reduce(&Scalar52::mul_internal(&ab, &constants::RR))
+    }
+
+    /// Compute `a^2` (mod l)
+    #[inline(never)]
+    #[allow(dead_code)] // XXX we don't expose square() via the Scalar API
+    pub fn square(&self) -> Scalar52 {
+        let aa = Scalar52::montgomery_reduce(&Scalar52::square_internal(self));
+        Scalar52::montgomery_reduce(&Scalar52::mul_internal(&aa, &constants::RR))
+    }
+
+    /// Compute `(a * b) / R` (mod l), where R is the Montgomery modulus 2^260
+    #[inline(never)]
+    pub fn montgomery_mul(a: &Scalar52, b: &Scalar52) -> Scalar52 {
+        Scalar52::montgomery_reduce(&Scalar52::mul_internal(a, b))
+    }
+
+    /// Compute `(a^2) / R` (mod l) in Montgomery form, where R is the Montgomery modulus 2^260
+    #[inline(never)]
+    pub fn montgomery_square(&self) -> Scalar52 {
+        Scalar52::montgomery_reduce(&Scalar52::square_internal(self))
+    }
+
+    /// Puts a Scalar52 in to Montgomery form, i.e. computes `a*R (mod l)`
+    #[inline(never)]
+    pub fn to_montgomery(&self) -> Scalar52 {
+        Scalar52::montgomery_mul(self, &constants::RR)
+    }
+
+    /// Takes a Scalar52 out of Montgomery form, i.e. computes `a/R (mod l)`
+    #[inline(never)]
+    pub fn from_montgomery(&self) -> Scalar52 {
+        let mut limbs = [0u128; 9];
+        for i in 0..5 {
+            limbs[i] = self[i] as u128;
+        }
+        Scalar52::montgomery_reduce(&limbs)
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Note: x is 2^253-1 which is slightly larger than the largest scalar produced by
+    /// this implementation (l-1), and should show there are no overflows for valid scalars
+    ///
+    /// x = 14474011154664524427946373126085988481658748083205070504932198000989141204991
+    /// x = 7237005577332262213973186563042994240801631723825162898930247062703686954002 mod l
+    /// x = 3057150787695215392275360544382990118917283750546154083604586903220563173085*R mod l in Montgomery form
+    pub static X: Scalar52 = Scalar52(
+        [0x000fffffffffffff, 0x000fffffffffffff, 0x000fffffffffffff, 0x000fffffffffffff,
+         0x00001fffffffffff]);
+
+    /// x^2 = 3078544782642840487852506753550082162405942681916160040940637093560259278169 mod l
+    pub static XX: Scalar52 = Scalar52(
+        [0x0001668020217559, 0x000531640ffd0ec0, 0x00085fd6f9f38a31, 0x000c268f73bb1cf4,
+         0x000006ce65046df0]);
+
+    /// x^2 = 4413052134910308800482070043710297189082115023966588301924965890668401540959*R mod l in Montgomery form
+    pub static XX_MONT: Scalar52 = Scalar52(
+        [0x000c754eea569a5c, 0x00063b6ed36cb215, 0x0008ffa36bf25886, 0x000e9183614e7543,
+         0x0000061db6c6f26f]);
+
+    /// y = 6145104759870991071742105800796537629880401874866217824609283457819451087098
+    pub static Y: Scalar52 = Scalar52(
+        [0x000b75071e1458fa, 0x000bf9d75e1ecdac, 0x000433d2baf0672b, 0x0005fffcc11fad13,
+         0x00000d96018bb825]);
+
+    /// x*y = 36752150652102274958925982391442301741 mod l
+    pub static XY: Scalar52 = Scalar52(
+        [0x000ee6d76ba7632d, 0x000ed50d71d84e02, 0x00000000001ba634, 0x0000000000000000,
+         0x0000000000000000]);
+
+    /// x*y = 658448296334113745583381664921721413881518248721417041768778176391714104386*R mod l in Montgomery form
+    pub static XY_MONT: Scalar52 = Scalar52(
+        [0x0006d52bf200cfd5, 0x00033fb1d7021570, 0x000f201bc07139d8, 0x0001267e3e49169e,
+         0x000007b839c00268]);
+
+    /// a = 2351415481556538453565687241199399922945659411799870114962672658845158063753
+    pub static A: Scalar52 = Scalar52(
+        [0x0005236c07b3be89, 0x0001bc3d2a67c0c4, 0x000a4aa782aae3ee, 0x0006b3f6e4fec4c4,
+         0x00000532da9fab8c]);
+
+    /// b = 4885590095775723760407499321843594317911456947580037491039278279440296187236
+    pub static B: Scalar52 = Scalar52(
+        [0x000d3fae55421564, 0x000c2df24f65a4bc, 0x0005b5587d69fb0b, 0x00094c091b013b3b,
+         0x00000acd25605473]);
+
+    /// a+b = 0
+    /// a-b = 4702830963113076907131374482398799845891318823599740229925345317690316127506
+    pub static AB: Scalar52 = Scalar52(
+        [0x000a46d80f677d12, 0x0003787a54cf8188, 0x0004954f0555c7dc, 0x000d67edc9fd8989,
+         0x00000a65b53f5718]);
+
+    // c = (2^512 - 1) % l = 1627715501170711445284395025044413883736156588369414752970002579683115011840
+    pub static C: Scalar52 = Scalar52(
+        [0x000611e3449c0f00, 0x000a768859347a40, 0x0007f5be65d00e1b, 0x0009a3dceec73d21,
+         0x00000399411b7c30]);
+
+    #[test]
+    fn mul_max() {
+        let res = Scalar52::mul(&X, &X);
+        for i in 0..5 {
+            assert!(res[i] == XX[i]);
+        }
+    }
+
+    #[test]
+    fn square_max() {
+        let res = X.square();
+        for i in 0..5 {
+            assert!(res[i] == XX[i]);
+        }
+    }
+
+    #[test]
+    fn montgomery_mul_max() {
+        let res = Scalar52::montgomery_mul(&X, &X);
+        for i in 0..5 {
+            assert!(res[i] == XX_MONT[i]);
+        }
+    }
+
+    #[test]
+    fn montgomery_square_max() {
+        let res = X.montgomery_square();
+        for i in 0..5 {
+            assert!(res[i] == XX_MONT[i]);
+        }
+    }
+
+    #[test]
+    fn mul() {
+        let res = Scalar52::mul(&X, &Y);
+        for i in 0..5 {
+            assert!(res[i] == XY[i]);
+        }
+    }
+
+    #[test]
+    fn montgomery_mul() {
+        let res = Scalar52::montgomery_mul(&X, &Y);
+        for i in 0..5 {
+            assert!(res[i] == XY_MONT[i]);
+        }
+    }
+
+    #[test]
+    fn add() {
+        let res = Scalar52::add(&A, &B);
+        let zero = Scalar52::zero();
+        for i in 0..5 {
+            assert!(res[i] == zero[i]);
+        }
+    }
+
+    #[test]
+    fn sub() {
+        let res = Scalar52::sub(&A, &B);
+        for i in 0..5 {
+            assert!(res[i] == AB[i]);
+        }
+    }
+
+    #[test]
+    fn from_bytes_wide() {
+        let bignum = [255u8; 64]; // 2^512 - 1
+        let reduced = Scalar52::from_bytes_wide(&bignum);
+        println!("{:?}", reduced);
+        for i in 0..5 {
+            assert!(reduced[i] == C[i]);
+        }
+    }
+}

--- a/test/symb_eval/scalar/test1.rs
+++ b/test/symb_eval/scalar/test1.rs
@@ -1,16 +1,5 @@
-//! Arithmetic mod \\(2\^{252} + 27742317777372353535851937790883648493\\)
-//! with five \\(52\\)-bit unsigned limbs.
-//!
-//! \\(51\\)-bit limbs would cover the desired bit range (\\(253\\)
-//! bits), but isn't large enough to reduce a \\(512\\)-bit number with
-//! Montgomery multiplication, so \\(52\\) bits is used instead.  To see
-//! that this is safe for intermediate results, note that the largest
-//! limb in a \\(5\times 5\\) product of \\(52\\)-bit limbs will be
-//!
-//! ```text
-//! (0xfffffffffffff^2) * 5 = 0x4ffffffffffff60000000000005 (107 bits).
-//! ```
 extern crate core;
+
 #[macro_use] mod crucible;
 mod scalar;
 mod constants;
@@ -162,24 +151,6 @@ fn f(_w : u64 ) -> bool {
         crucible_assert!(is_valid(y));
         crucible_assert!(y == a + b || y == a + b - L());
     }
-
-    /*
-    // Scalar52::sub is a correct implemnetation of subtraction modulo L.
-    {
-        let a = Int512::symbolic("sub_a");
-        let b = Int512::symbolic("sub_b");
-        crucible_assume!(is_valid(a));
-        crucible_assume!(is_valid(b));
-
-        let s_a = Scalar52::from(a);
-        let s_b = Scalar52::from(b);
-        let s_y = Scalar52::sub(&s_a, &s_b);
-
-        let y = Int512::from(s_y);
-        crucible_assert!(is_valid(y));
-        crucible_assert!(y == a - b || y == a - b + L());
-    }
-    */
 
     return true;
 }

--- a/test/symb_eval/scalar/test1.rs
+++ b/test/symb_eval/scalar/test1.rs
@@ -10,16 +10,20 @@
 //! ```text
 //! (0xfffffffffffff^2) * 5 = 0x4ffffffffffff60000000000005 (107 bits).
 //! ```
-
 extern crate core;
-//use core::fmt::Debug;
-use std::ops::{Index, IndexMut};
+#[macro_use] mod crucible;
+mod scalar;
+mod constants;
+mod int512;
 
-use self::int512::Int512;
+use scalar::Scalar52;
+use int512::Int512;
 
 
-impl From<Scalar64> for Int512 {
-    fn from(x: Scalar64) -> Int512 {
+// Conversions: Scalar52 <-> Int512
+
+impl From<Scalar52> for Int512 {
+    fn from(x: Scalar52) -> Int512 {
         let mut acc = Int512::from(0_i32);
         for i in 0..5 {
             acc = acc | (Int512::from(x.0[i]) << (52 * i as u32));
@@ -28,9 +32,9 @@ impl From<Scalar64> for Int512 {
     }
 }
 
-impl From<Int512> for Scalar64 {
-    fn from(x: Int512) -> Scalar64 {
-        let mut acc = Scalar64([0; 5]);
+impl From<Int512> for Scalar52 {
+    fn from(x: Int512) -> Scalar52 {
+        let mut acc = Scalar52([0; 5]);
         let mask: Int512 = Int512::from((1_u64 << 52) - 1);
         for i in 0..5 {
             acc.0[i] = u64::from((x >> (52 * i as u32)) & mask);
@@ -38,6 +42,9 @@ impl From<Int512> for Scalar64 {
         acc
     }
 }
+
+
+// Conversions: Int512 <-> bytes
 
 impl From<[u8; 32]> for Int512 {
     fn from(x: [u8; 32]) -> Int512 {
@@ -60,10 +67,11 @@ impl From<Int512> for [u8; 32] {
     }
 }
 
+
+/// `constants::L` (the modulus), represented as an `Int512`.
 pub fn L() -> Int512 {
     (Int512::from(1_i32) << 252) +
-        (Int512::from(0x5812631a5cf5d3ed_u64) |
-         (Int512::from(0x14def9dea2f79cd6_u64) << 64))
+        (Int512::from(0x5812631a5cf5d3ed_u64) | (Int512::from(0x14def9dea2f79cd6_u64) << 64))
 }
 
 /// Check if an integer is in the range `0 .. L`.
@@ -71,109 +79,48 @@ pub fn is_valid(x: Int512) -> bool {
     Int512::from(0_i32) <= x && x < L()
 }
 
-fn crucible_u64(_x: &'static str) -> u64 { unimplemented!() }
-
-macro_rules! crucible_scalar64 {
-    ($desc:expr) => {
-        Scalar64([
-            $crate::crucible_u64(concat!($desc, "_0")),
-            $crate::crucible_u64(concat!($desc, "_1")),
-            $crate::crucible_u64(concat!($desc, "_2")),
-            $crate::crucible_u64(concat!($desc, "_3")),
-            $crate::crucible_u64(concat!($desc, "_4")),
-        ])
-    };
-}
-
-#[allow(unused_variables)]
-fn crucible_assert_impl(
-    cond: bool,
-    cond_str: &'static str,
-    file: &'static str,
-    line: u32,
-    col: u32,
-) -> () {
-    ()
-}
-
-#[allow(unused_variables)]
-fn crucible_assume_impl(
-    cond: bool,
-    cond_str: &'static str,
-    file: &'static str,
-    line: u32,
-    col: u32,
-) -> () {
-    ()
-}
-
-macro_rules! crucible_assert {
-    ($e:expr) => {
-        crucible_assert_impl($e, stringify!($e), file!(), line!(), column!())
-    };
-}
-
-macro_rules! crucible_assume {
-    ($e:expr) => {
-        crucible_assume_impl($e, stringify!($e), file!(), line!(), column!())
-    };
-}
-
-macro_rules! crucible_debug_integer {
-    ($e:expr) => { crucible_debug_integer!($e, stringify!($e)) };
-    ($e:expr, $desc:expr) => {
-        crucible_assume!(integer::eq($e, integer::symbolic($desc)))
-    };
-}
-
-
-
-#[cfg(with_main)]
-fn main() {
-   println!("{:?}", f(ARG));
-}
 
 fn f(_w : u64 ) -> bool {
-    // Int512 -> Scalar64 -> Int512 conversion is the identity function.
+    // Int512 -> Scalar52 -> Int512 conversion is the identity function.
     {
-        let i = Int512::symbolic("isi");
+        let i = Int512::symbolic("int_to_from_scalar");
         crucible_assume!(is_valid(i));
-        let s = Scalar64::from(i);
+        let s = Scalar52::from(i);
         let i2 = Int512::from(s);
         crucible_assert!(i2 == i);
     }
 
-    // Scalar64 -> Int512 -> Scalar64 conversion is the identity function.
+    // Scalar52 -> Int512 -> Scalar52 conversion is the identity function.
     {
-        let s = crucible_scalar64!("sis");
+        let s = crucible_scalar64!("scalar_to_from_int");
         for i in 0..5 {
             crucible_assume!(s.0[i] < 1 << 52);
         }
         let i = Int512::from(s);
-        let s2 = Scalar64::from(i);
+        let s2 = Scalar52::from(i);
         for i in 0..5 {
             crucible_assert!(s2.0[i] == s.0[i]);
         }
     }
 
-    // Serialization is correct: Scalar64 -> [u8] -> Scalar64 is the identity.
+    // Serialization is correct: Scalar52 -> [u8] -> Scalar52 is the identity.
     {
-        let i = Int512::symbolic("isbs");
+        let i = Int512::symbolic("scalar_to_from_bytes");
         crucible_assume!(is_valid(i));
-        let s = Scalar64::from(i);
+        let s = Scalar52::from(i);
         let b = s.to_bytes();
-        let s2 = Scalar64::from_bytes(&b);
+        let s2 = Scalar52::from_bytes(&b);
         for i in 0..5 {
             crucible_assert!(s2.0[i] == s.0[i]);
         }
     }
 
-    // [u8] ->  Scalar64 -> [u8] is the identity.
+    // [u8] ->  Scalar52 -> [u8] is the identity.
     {
-        let i = Int512::symbolic("ibsb");
+        let i = Int512::symbolic("scalar_from_to_bytes");
         crucible_assume!(is_valid(i));
         let b = <[u8; 32]>::from(i);
-        let s = Scalar64::from_bytes(&b);
+        let s = Scalar52::from_bytes(&b);
         let b2 = s.to_bytes();
         for i in 0..32 {
             crucible_assert!(b2[i] == b[i]);
@@ -181,11 +128,11 @@ fn f(_w : u64 ) -> bool {
     }
 
     // Serialization uses the little-endian format defined in Int512 -> [u8]: the two conversions
-    // Int512 -> Scalar64 -> [u8] and Int512 -> [u8] produce identical results.
+    // Int512 -> Scalar52 -> [u8] and Int512 -> [u8] produce identical results.
     {
-        let i = Int512::symbolic("isb");
+        let i = Int512::symbolic("scalar_int_to_bytes");
         crucible_assume!(is_valid(i));
-        let s = Scalar64::from(i);
+        let s = Scalar52::from(i);
         let b = s.to_bytes();
         let b2 = <[u8; 32]>::from(i);
         for i in 0..32 {
@@ -193,8 +140,8 @@ fn f(_w : u64 ) -> bool {
         }
     }
 
-    // Scalar64::add is a correct implemnetation of addition modulo L: Int512 -> Scalar64 +
-    // Scalar64::add + Scalar64 -> Int512 produces the same result as using Int512::add +
+    // Scalar52::add is a correct implemnetation of addition modulo L: Int512 -> Scalar52 +
+    // Scalar52::add + Scalar52 -> Int512 produces the same result as using Int512::add +
     // Int512::rem directly.
     {
         let a = Int512::symbolic("add_a");
@@ -202,9 +149,9 @@ fn f(_w : u64 ) -> bool {
         crucible_assume!(is_valid(a));
         crucible_assume!(is_valid(b));
 
-        let s_a = Scalar64::from(a);
-        let s_b = Scalar64::from(b);
-        let s_y = Scalar64::add(&s_a, &s_b);
+        let s_a = Scalar52::from(a);
+        let s_b = Scalar52::from(b);
+        let s_y = Scalar52::add(&s_a, &s_b);
 
         let y = Int512::from(s_y);
         // We'd like to say `y == (a + b) % L`, but the solver can't handle it (times out).
@@ -216,451 +163,29 @@ fn f(_w : u64 ) -> bool {
         crucible_assert!(y == a + b || y == a + b - L());
     }
 
+    /*
+    // Scalar52::sub is a correct implemnetation of subtraction modulo L.
+    {
+        let a = Int512::symbolic("sub_a");
+        let b = Int512::symbolic("sub_b");
+        crucible_assume!(is_valid(a));
+        crucible_assume!(is_valid(b));
+
+        let s_a = Scalar52::from(a);
+        let s_b = Scalar52::from(b);
+        let s_y = Scalar52::sub(&s_a, &s_b);
+
+        let y = Int512::from(s_y);
+        crucible_assert!(is_valid(y));
+        crucible_assert!(y == a - b || y == a - b + L());
+    }
+    */
+
     return true;
 }
 
 const ARG: u64 = 20;
-
-
-
-
-
-mod constants {
-    use Scalar64;
-
-    /// `L` is the order of base point, i.e. 2^252 + 27742317777372353535851937790883648493
-    pub(crate) const L: Scalar64 = Scalar64([ 0x0002631a5cf5d3ed, 0x000dea2f79cd6581, 0x000000000014def9, 0x0000000000000000, 0x0000100000000000 ]);
-
-    /// `L` * `LFACTOR` = -1 (mod 2^52)
-    pub(crate) const LFACTOR: u64 = 0x51da312547e1b;
-
-    /// `R` = R % L where R = 2^260
-    pub(crate) const R: Scalar64 = Scalar64([ 0x000f48bd6721e6ed, 0x0003bab5ac67e45a, 0x000fffffeb35e51b, 0x000fffffffffffff, 0x00000fffffffffff ]);
-
-    /// `RR` = (R^2) % L where R = 2^260
-    pub(crate) const RR: Scalar64 = Scalar64([ 0x0009d265e952d13b, 0x000d63c715bea69f, 0x0005be65cb687604, 0x0003dceec73d217f, 0x000009411b7c309a ]);
-}
-
-
-
-
-/// The `Scalar64` struct represents an element in
-/// \\(\mathbb Z / \ell \mathbb Z\\) as 5 \\(52\\)-bit limbs.
-#[derive(Copy, Clone)]
-pub struct Scalar64(pub [u64; 5]);
-
-/*
-impl Debug for Scalar64 {
-    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-        write!(f, "Scalar64: {:?}", &self.0[..])
-    }
-}*/
-
-/*
-impl Deref for Scalar64 {
-    type Target = [u64; 5];
-    fn deref(&self) -> &[u64; 5] {
-        &self.0
-    }
-}
-
-impl DerefMut for Scalar64 {
-    fn deref_mut(&mut self) -> &mut [u64; 5] {
-        &mut self.0
-    }
-}
-*/
-
-impl Index<usize> for Scalar64 {
-    type Output = u64;
-    fn index(&self, _index: usize) -> &u64 {
-        &(self.0[_index])
-    }
-}
-
-impl IndexMut<usize> for Scalar64 {
-    fn index_mut(&mut self, _index: usize) -> &mut u64 {
-        &mut (self.0[_index])
-    }
-}
-
-/// u64 * u64 = u128 multiply helper
-#[inline(always)]
-fn m(x: u64, y: u64) -> u128 {
-    (x as u128) * (y as u128)
-}
-
-impl Scalar64 {
-    /// Return the zero scalar
-    pub fn zero() -> Scalar64 {
-        Scalar64([0,0,0,0,0])
-    }
-
-    /// Unpack a 32 byte / 256 bit scalar into 5 52-bit limbs.
-    pub fn from_bytes(bytes: &[u8; 32]) -> Scalar64 {
-        let mut words = [0u64; 4];
-        for i in 0..4 {
-            for j in 0..8 {
-                words[i] |= (bytes[(i * 8) + j] as u64) << (j * 8);
-            }
-        }
-
-        let mask = (1u64 << 52) - 1;
-        let top_mask = (1u64 << 48) - 1;
-        let mut s = Scalar64::zero();
-
-        s.0[ 0] =   words[0]                            & mask;
-        s.0[ 1] = ((words[0] >> 52) | (words[1] << 12)) & mask;
-        s.0[ 2] = ((words[1] >> 40) | (words[2] << 24)) & mask;
-        s.0[ 3] = ((words[2] >> 28) | (words[3] << 36)) & mask;
-        s.0[ 4] =  (words[3] >> 16)                     & top_mask;
-
-        s
-    }
-
-    /*
-    /// Reduce a 64 byte / 512 bit scalar mod l
-    pub fn from_bytes_wide(bytes: &[u8; 64]) -> Scalar64 {
-        let mut words = [0u64; 8];
-        for i in 0..8 {
-            for j in 0..8 {
-                words[i] |= (bytes[(i * 8) + j] as u64) << (j * 8);
-            }
-        }
-
-        let mask = (1u64 << 52) - 1;
-        let mut lo = Scalar64::zero();
-        let mut hi = Scalar64::zero();
-
-        lo[0] =   words[ 0]                             & mask;
-        lo[1] = ((words[ 0] >> 52) | (words[ 1] << 12)) & mask;
-        lo[2] = ((words[ 1] >> 40) | (words[ 2] << 24)) & mask;
-        lo[3] = ((words[ 2] >> 28) | (words[ 3] << 36)) & mask;
-        lo[4] = ((words[ 3] >> 16) | (words[ 4] << 48)) & mask;
-        hi[0] =  (words[ 4] >>  4)                      & mask;
-        hi[1] = ((words[ 4] >> 56) | (words[ 5] <<  8)) & mask;
-        hi[2] = ((words[ 5] >> 44) | (words[ 6] << 20)) & mask;
-        hi[3] = ((words[ 6] >> 32) | (words[ 7] << 32)) & mask;
-        hi[4] =   words[ 7] >> 20                             ;
-
-        lo = Scalar64::montgomery_mul(&lo, &constants::R);  // (lo * R) / R = lo
-        hi = Scalar64::montgomery_mul(&hi, &constants::RR); // (hi * R^2) / R = hi * R
-
-        Scalar64::add(&hi, &lo)
-    }
-    */
-
-    /// Pack the limbs of this `Scalar64` into 32 bytes
-    pub fn to_bytes(&self) -> [u8; 32] {
-        let mut s = [0u8; 32];
-
-        s[0]  =  (self.0[ 0] >>  0)                      as u8;
-        s[1]  =  (self.0[ 0] >>  8)                      as u8;
-        s[2]  =  (self.0[ 0] >> 16)                      as u8;
-        s[3]  =  (self.0[ 0] >> 24)                      as u8;
-        s[4]  =  (self.0[ 0] >> 32)                      as u8;
-        s[5]  =  (self.0[ 0] >> 40)                      as u8;
-        s[6]  = ((self.0[ 0] >> 48) | (self.0[ 1] << 4)) as u8;
-        s[7]  =  (self.0[ 1] >>  4)                      as u8;
-        s[8]  =  (self.0[ 1] >> 12)                      as u8;
-        s[9]  =  (self.0[ 1] >> 20)                      as u8;
-        s[10] =  (self.0[ 1] >> 28)                      as u8;
-        s[11] =  (self.0[ 1] >> 36)                      as u8;
-        s[12] =  (self.0[ 1] >> 44)                      as u8;
-        s[13] =  (self.0[ 2] >>  0)                      as u8;
-        s[14] =  (self.0[ 2] >>  8)                      as u8;
-        s[15] =  (self.0[ 2] >> 16)                      as u8;
-        s[16] =  (self.0[ 2] >> 24)                      as u8;
-        s[17] =  (self.0[ 2] >> 32)                      as u8;
-        s[18] =  (self.0[ 2] >> 40)                      as u8;
-        s[19] = ((self.0[ 2] >> 48) | (self.0[ 3] << 4)) as u8;
-        s[20] =  (self.0[ 3] >>  4)                      as u8;
-        s[21] =  (self.0[ 3] >> 12)                      as u8;
-        s[22] =  (self.0[ 3] >> 20)                      as u8;
-        s[23] =  (self.0[ 3] >> 28)                      as u8;
-        s[24] =  (self.0[ 3] >> 36)                      as u8;
-        s[25] =  (self.0[ 3] >> 44)                      as u8;
-        s[26] =  (self.0[ 4] >>  0)                      as u8;
-        s[27] =  (self.0[ 4] >>  8)                      as u8;
-        s[28] =  (self.0[ 4] >> 16)                      as u8;
-        s[29] =  (self.0[ 4] >> 24)                      as u8;
-        s[30] =  (self.0[ 4] >> 32)                      as u8;
-        s[31] =  (self.0[ 4] >> 40)                      as u8;
-
-        s
-    }
-
-    /// Compute `a + b` (mod l)
-    pub fn add(a: &Scalar64, b: &Scalar64) -> Scalar64 {
-        let mut sum = Scalar64::zero();
-        let mask = (1u64 << 52) - 1;
-
-        // a + b
-        let mut carry: u64 = 0;
-        for i in 0..5 {
-            carry = a.0[i] + b.0[i] + (carry >> 52);
-            sum.0[i] = carry & mask;
-        }
-
-        // subtract l if the sum is >= l
-        Scalar64::sub(&sum, &constants::L)
-    }
-
-    /// Compute `a - b` (mod l)
-    pub fn sub(a: &Scalar64, b: &Scalar64) -> Scalar64 {
-        let mut difference = Scalar64::zero();
-        let mask = (1u64 << 52) - 1;
-
-        // a - b
-        let mut borrow: u64 = 0;
-        for i in 0..5 {
-            borrow = a.0[i].wrapping_sub(b.0[i] + (borrow >> 63));
-            difference.0[i] = borrow & mask;
-        }
-
-        // conditionally add l if the difference is negative
-        let underflow_mask = ((borrow >> 63) ^ 1).wrapping_sub(1);
-        let mut carry: u64 = 0;
-        for i in 0..5 {
-            carry = (carry >> 52) + difference.0[i] + (constants::L.0[i] & underflow_mask);
-            difference.0[i] = carry & mask;
-        }
-
-        difference
-    }
-
-    /*
-    /// Compute `a * b`
-    #[inline(always)]
-    pub (crate) fn mul_internal(a: &Scalar64, b: &Scalar64) -> [u128; 9] {
-        let mut z = [0u128; 9];
-
-        z[0] = m(a[0],b[0]);
-        z[1] = m(a[0],b[1]) + m(a[1],b[0]);
-        z[2] = m(a[0],b[2]) + m(a[1],b[1]) + m(a[2],b[0]);
-        z[3] = m(a[0],b[3]) + m(a[1],b[2]) + m(a[2],b[1]) + m(a[3],b[0]);
-        z[4] = m(a[0],b[4]) + m(a[1],b[3]) + m(a[2],b[2]) + m(a[3],b[1]) + m(a[4],b[0]);
-        z[5] =                m(a[1],b[4]) + m(a[2],b[3]) + m(a[3],b[2]) + m(a[4],b[1]);
-        z[6] =                               m(a[2],b[4]) + m(a[3],b[3]) + m(a[4],b[2]);
-        z[7] =                                              m(a[3],b[4]) + m(a[4],b[3]);
-        z[8] =                                                             m(a[4],b[4]);
-
-        z
-    }
-
-    /// Compute `a^2`
-    #[inline(always)]
-    fn square_internal(a: &Scalar64) -> [u128; 9] {
-        let aa = [
-            a[0]*2,
-            a[1]*2,
-            a[2]*2,
-            a[3]*2,
-        ];
-
-        [
-            m( a[0],a[0]),
-            m(aa[0],a[1]),
-            m(aa[0],a[2]) + m( a[1],a[1]),
-            m(aa[0],a[3]) + m(aa[1],a[2]),
-            m(aa[0],a[4]) + m(aa[1],a[3]) + m( a[2],a[2]),
-                            m(aa[1],a[4]) + m(aa[2],a[3]),
-                                            m(aa[2],a[4]) + m( a[3],a[3]),
-                                                            m(aa[3],a[4]),
-                                                                            m(a[4],a[4])
-        ]
-    }
-
-    /// Compute `limbs/R` (mod l), where R is the Montgomery modulus 2^260
-    #[inline(always)]
-    pub (crate) fn montgomery_reduce(limbs: &[u128; 9]) -> Scalar64 {
-
-        #[inline(always)]
-        fn part1(sum: u128) -> (u128, u64) {
-            let p = (sum as u64).wrapping_mul(constants::LFACTOR) & ((1u64 << 52) - 1);
-            ((sum + m(p,constants::L[0])) >> 52, p)
-        }
-
-        #[inline(always)]
-        fn part2(sum: u128) -> (u128, u64) {
-            let w = (sum as u64) & ((1u64 << 52) - 1);
-            (sum >> 52, w)
-        }
-
-        // note: l3 is zero, so its multiplies can be skipped
-        let l = &constants::L;
-
-        // the first half computes the Montgomery adjustment factor n, and begins adding n*l to make limbs divisible by R
-        let (carry, n0) = part1(        limbs[0]);
-        let (carry, n1) = part1(carry + limbs[1] + m(n0,l[1]));
-        let (carry, n2) = part1(carry + limbs[2] + m(n0,l[2]) + m(n1,l[1]));
-        let (carry, n3) = part1(carry + limbs[3]              + m(n1,l[2]) + m(n2,l[1]));
-        let (carry, n4) = part1(carry + limbs[4] + m(n0,l[4])              + m(n2,l[2]) + m(n3,l[1]));
-
-        // limbs is divisible by R now, so we can divide by R by simply storing the upper half as the result
-        let (carry, r0) = part2(carry + limbs[5]              + m(n1,l[4])              + m(n3,l[2]) + m(n4,l[1]));
-        let (carry, r1) = part2(carry + limbs[6]                           + m(n2,l[4])              + m(n4,l[2]));
-        let (carry, r2) = part2(carry + limbs[7]                                        + m(n3,l[4])             );
-        let (carry, r3) = part2(carry + limbs[8]                                                     + m(n4,l[4]));
-        let         r4 = carry as u64;
-
-        // result may be >= l, so attempt to subtract l
-        Scalar64::sub(&Scalar64([r0,r1,r2,r3,r4]), l)
-    }
-
-    /// Compute `a * b` (mod l)
-    #[inline(never)]
-    pub fn mul(a: &Scalar64, b: &Scalar64) -> Scalar64 {
-        let ab = Scalar64::montgomery_reduce(&Scalar64::mul_internal(a, b));
-        Scalar64::montgomery_reduce(&Scalar64::mul_internal(&ab, &constants::RR))
-    }
-
-    /// Compute `a^2` (mod l)
-    #[inline(never)]
-    #[allow(dead_code)] // XXX we don't expose square() via the Scalar API
-    pub fn square(&self) -> Scalar64 {
-        let aa = Scalar64::montgomery_reduce(&Scalar64::square_internal(self));
-        Scalar64::montgomery_reduce(&Scalar64::mul_internal(&aa, &constants::RR))
-    }
-
-    /// Compute `(a * b) / R` (mod l), where R is the Montgomery modulus 2^260
-    #[inline(never)]
-    pub fn montgomery_mul(a: &Scalar64, b: &Scalar64) -> Scalar64 {
-        Scalar64::montgomery_reduce(&Scalar64::mul_internal(a, b))
-    }
-
-    /// Compute `(a^2) / R` (mod l) in Montgomery form, where R is the Montgomery modulus 2^260
-    #[inline(never)]
-    pub fn montgomery_square(&self) -> Scalar64 {
-        Scalar64::montgomery_reduce(&Scalar64::square_internal(self))
-    }
-
-    /// Puts a Scalar64 in to Montgomery form, i.e. computes `a*R (mod l)`
-    #[inline(never)]
-    pub fn to_montgomery(&self) -> Scalar64 {
-        Scalar64::montgomery_mul(self, &constants::RR)
-    }
-
-    /// Takes a Scalar64 out of Montgomery form, i.e. computes `a/R (mod l)`
-    #[inline(never)]
-    pub fn from_montgomery(&self) -> Scalar64 {
-        let mut limbs = [0u128; 9];
-        for i in 0..5 {
-            limbs[i] = self[i] as u128;
-        }
-        Scalar64::montgomery_reduce(&limbs)
-    }
-    */
-}
-
-
-
-
-mod int512 {
-    use core::ops::{Add, Sub, Mul, Div, Rem, BitAnd, BitOr, BitXor, Shl, Shr};
-    use core::cmp::{Ord, PartialOrd, Ordering};
-
-    #[derive(Copy)]
-    pub struct Int512 {}
-
-    pub fn clone(_i: &Int512) -> Int512 { unimplemented!() }
-    impl Clone for Int512 {
-        fn clone(&self) -> Int512 { clone(self) }
-    }
-
-    pub fn symbolic(_x: &'static str) -> Int512 { unimplemented!() }
-    impl Int512 {
-        pub fn symbolic(x: &'static str) -> Int512 { symbolic(x) }
-    }
-
-    macro_rules! binop {
-        ($Op:ident, $op:ident) => {
-            pub fn $op(_x: Int512, _y: Int512) -> Int512 { unimplemented!() }
-
-            impl Int512 {
-                pub fn $op(self, other: Int512) -> Int512 { $op(self, other) }
-            }
-
-            impl $Op<Int512> for Int512 {
-                type Output = Int512;
-                fn $op(self, other: Int512) -> Int512 { $op(self, other) }
-            }
-        };
-    }
-    binop!(Add, add);
-    binop!(Sub, sub);
-    binop!(Mul, mul);
-    binop!(Div, div);
-    binop!(Rem, rem);
-    binop!(BitAnd, bitand);
-    binop!(BitOr, bitor);
-    binop!(BitXor, bitxor);
-
-    macro_rules! shift_op {
-        ($Op:ident, $op:ident) => {
-            pub fn $op(_x: Int512, _bits: u32) -> Int512 { unimplemented!() }
-
-            impl Int512 {
-                pub fn $op(self, bits: u32) -> Int512 { $op(self, bits) }
-            }
-
-            impl $Op<u32> for Int512 {
-                type Output = Int512;
-                fn $op(self, bits: u32) -> Int512 { $op(self, bits) }
-            }
-        };
-    }
-    shift_op!(Shl, shl);
-    shift_op!(Shr, shr);
-
-    pub fn eq(_x: Int512, _y: Int512) -> bool { unimplemented!() }
-    impl PartialEq for Int512 {
-        fn eq(&self, other: &Int512) -> bool { eq(*self, *other) }
-        fn ne(&self, other: &Int512) -> bool { !eq(*self, *other) }
-    }
-    impl Eq for Int512 {}
-
-    pub fn lt(_x: Int512, _y: Int512) -> bool { unimplemented!() }
-    impl PartialOrd for Int512 {
-        fn partial_cmp(&self, other: &Int512) -> Option<Ordering> {
-            Some(self.cmp(other))
-        }
-    }
-    impl Ord for Int512 {
-        fn cmp(&self, other: &Int512) -> Ordering {
-            if eq(*self, *other) { Ordering::Equal }
-            else if lt(*self, *other) { Ordering::Less }
-            else { Ordering::Greater }
-        }
-    }
-
-    macro_rules! prim_cast {
-        ($Prim:ident) => {
-            pub mod $Prim {
-                use super::Int512;
-                pub fn from_prim(_x: $Prim) -> Int512 { unimplemented!() }
-                pub fn as_prim(_x: Int512) -> $Prim { unimplemented!() }
-            }
-
-            impl From<$Prim> for Int512 {
-                fn from(x: $Prim) -> Int512 { self::$Prim::from_prim(x) }
-            }
-
-            impl From<Int512> for $Prim {
-                fn from(x: Int512) -> $Prim { self::$Prim::as_prim(x) }
-            }
-        };
-    }
-    prim_cast!(u8);
-    prim_cast!(u16);
-    prim_cast!(u32);
-    prim_cast!(u64);
-    prim_cast!(u128);
-    prim_cast!(usize);
-    prim_cast!(i8);
-    prim_cast!(i16);
-    prim_cast!(i32);
-    prim_cast!(i64);
-    prim_cast!(i128);
-    prim_cast!(isize);
+#[cfg(with_main)]
+fn main() {
+   println!("{:?}", f(ARG));
 }


### PR DESCRIPTION
This adds a new test case, `test/symb_eval/scalar/test1.rs`, that checks the correctness of `Scalar64::add` by comparing `add(a, b)` to the result of computing `(a + b) % L` directly using 512-bit arithmetic.

The main idea is to define an abstract type `Integer` in Rust, and use overrides and custom translation to implement it as a signed 512-bit integer within the verifier.  The implementation of `Integer` accounts for most of the verifier changes in this branch.  Specifically:

 * In `TransTy.hs` `tyToRepr`, the ADT type `integer::Integer` is translated specially as `BVType 512`.
 * In `TransCustom.hs`, a bunch of new `customOps` provide implementations for operations such as `integer::add`.
 * In `Overrides.hs`, I added an override for `integer::symbolic` along the same lines as `crucible_u64` and such, since I wasn't sure how to implement the same behavior as a `CustomOp`.

@sweirich, please take a look at this when you get a chance, and let me know if there are any improvements I should make.

A couple questions in particular:

 * What's the difference between overrides and custom ops?  They seem to do similar things - is there a reason to prefer using one form over the other?
 * Are operator overloads supposed to be working in the current version?  I initially tried `impl Add for Integer` and so on, but mir-verifier didn't seem to be able to resolve the `Add::add` calls, so I switched everything to use direct function calls instead.
