### PR TITLE
String formatting support

### DIFF
--- a/lib/crucible/any.rs
+++ b/lib/crucible/any.rs
@@ -1,0 +1,19 @@
+pub struct Any(());
+
+impl Any {
+    /// Wrap an arbitrary value in `Any`.
+    pub fn new<T>(x: T) -> Any {
+        unimplemented!()
+    }
+
+    /// Try to downcast to concrete type `T`.  This succeeds if the type passed to `new` has the
+    /// same Crucible representation as the type passed to `downcast` (similar to the condition on
+    /// `crucible_identity_transmute`).  There is not actually any way to check for an exact type
+    /// match at the Rust level.
+    ///
+    /// This function is unsafe because `new` + `downcast` is equivalent to
+    /// `crucible_identity_transmute`.
+    pub unsafe fn downcast<T>(self) -> T {
+        unimplemented!()
+    }
+}

--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 #![feature(core_intrinsics)]
+#![feature(crucible_intrinsics)]
 
-pub mod any;
+pub use core::crucible::any;
 pub mod bitvector;
 pub mod symbolic;
 pub mod vector;

--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![feature(core_intrinsics)]
 
+pub mod any;
 pub mod bitvector;
 pub mod symbolic;
 pub mod vector;

--- a/lib/liballoc/lib.rs
+++ b/lib/liballoc/lib.rs
@@ -122,6 +122,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(mem_take)]
+#![feature(crucible_intrinsics)]
 
 // Allow testing this library
 

--- a/lib/liballoc/str.rs
+++ b/lib/liballoc/str.rs
@@ -587,5 +587,5 @@ impl str {
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
 pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
-    Box::from_raw(Box::into_raw(v) as *mut str)
+    mem::crucible_identity_transmute(v)
 }

--- a/lib/liballoc/vec.rs
+++ b/lib/liballoc/vec.rs
@@ -686,9 +686,12 @@ impl<T> Vec<T> {
     /// [`drain`]: #method.drain
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn truncate(&mut self, len: usize) {
-        while self.len() > len {
-            self.pop();
+        if len >= self.len() {
+            return;
         }
+        let old = mem::replace(&mut self.data, Vector::new());
+        let (before, after) = old.split_at(len);
+        self.data = before;
     }
 
     /// Extracts a slice containing the entire vector.

--- a/lib/libcore/char/convert.rs
+++ b/lib/libcore/char/convert.rs
@@ -2,7 +2,7 @@
 
 use crate::convert::TryFrom;
 use crate::fmt;
-use crate::mem::transmute;
+use crate::mem::crucible_identity_transmute;
 #[cfg(from_str)] use crate::str::FromStr;
 
 use super::MAX;
@@ -99,7 +99,7 @@ pub fn from_u32(i: u32) -> Option<char> {
 #[inline]
 #[stable(feature = "char_from_unchecked", since = "1.5.0")]
 pub unsafe fn from_u32_unchecked(i: u32) -> char {
-    transmute(i)
+    crucible_identity_transmute(i)
 }
 
 #[stable(feature = "char_convert", since = "1.13.0")]

--- a/lib/libcore/crucible/any.rs
+++ b/lib/libcore/crucible/any.rs
@@ -1,8 +1,12 @@
+/// Dynamically-typed wrapper, corresponding to Crucible's `AnyType`.
+#[unstable(feature = "crucible_intrinsics", issue = "0")]
+#[derive(Clone, Copy)]
 pub struct Any(());
 
 impl Any {
     /// Wrap an arbitrary value in `Any`.
-    pub fn new<T>(x: T) -> Any {
+    #[unstable(feature = "crucible_intrinsics", issue = "0")]
+    pub fn new<T: Copy>(x: T) -> Any {
         unimplemented!()
     }
 
@@ -13,7 +17,9 @@ impl Any {
     ///
     /// This function is unsafe because `new` + `downcast` is equivalent to
     /// `crucible_identity_transmute`.
+    #[unstable(feature = "crucible_intrinsics", issue = "0")]
     pub unsafe fn downcast<T>(self) -> T {
         unimplemented!()
     }
 }
+

--- a/lib/libcore/crucible/mod.rs
+++ b/lib/libcore/crucible/mod.rs
@@ -1,0 +1,2 @@
+#[unstable(feature = "crucible_intrinsics", issue = "0")]
+pub mod any;

--- a/lib/libcore/lib.rs
+++ b/lib/libcore/lib.rs
@@ -246,3 +246,7 @@ mod core_arch;
 #[stable(feature = "simd_arch", since = "1.27.0")]
 #[cfg(simd)]
 pub use core_arch::arch;
+
+
+#[unstable(feature = "crucible_intrinsics", issue = "0")]
+pub mod crucible;

--- a/lib/libcore/mem/mod.rs
+++ b/lib/libcore/mem/mod.rs
@@ -824,6 +824,7 @@ pub fn discriminant<T>(v: &T) -> Discriminant<T> {
 /// Specialized `transmute` that requires the input and output types to have the same Crucible
 /// representation.  Useful for casting away lifetimes.
 #[unstable(feature = "crucible_intrinsics", issue = "0")]
-pub unsafe fn crucible_identity_transmute<T, U>(x: T) -> U {
-    unimplemented!()
+pub const unsafe fn crucible_identity_transmute<T, U>(x: T) -> U {
+    // Needs to be a const fn for some `str` methods
+    crucible_identity_transmute(x)
 }

--- a/lib/libcore/slice/mod.rs
+++ b/lib/libcore/slice/mod.rs
@@ -5229,6 +5229,7 @@ impl<A> SliceOrd<A> for [A]
 
 // memcmp compares a sequence of unsigned bytes lexicographically.
 // this matches the order we want for [u8], but no others (not even [i8]).
+/* crux: use default impl instead of unsafe memcmp
 impl SliceOrd<u8> for [u8] {
     #[inline]
     fn compare(&self, other: &[u8]) -> Ordering {
@@ -5245,6 +5246,7 @@ impl SliceOrd<u8> for [u8] {
         }
     }
 }
+*/
 
 #[doc(hidden)]
 /// Trait implemented for types that can be compared for equality using
@@ -5289,6 +5291,7 @@ impl<T> SliceContains for T where T: PartialEq {
     }
 }
 
+/* crux: use default impl instead of unsafe memchr
 #[cfg(memchr)]
 impl SliceContains for u8 {
     fn slice_contains(&self, x: &[Self]) -> bool {
@@ -5304,3 +5307,4 @@ impl SliceContains for i8 {
         memchr::memchr(byte, bytes).is_some()
     }
 }
+*/

--- a/src/Mir/JSON.hs
+++ b/src/Mir/JSON.hs
@@ -15,8 +15,9 @@ import qualified Data.HashMap.Lazy as HML
 import qualified Data.Map.Strict   as Map
 import qualified Data.Scientific   as Scientific
 
-import Data.Word(Word64)
+import Data.Word (Word64, Word8)
 import Data.Bits
+import qualified Data.ByteString as BS
 import qualified Data.Char as Char
 import Data.Text (Text,  unpack)
 import qualified Data.Text as T
@@ -505,10 +506,10 @@ instance FromJSON RustcRenderedConst where
         Just (String "str") -> do
             val <- v .: "val"
             let f sci = case Scientific.toBoundedInteger sci of
-                    Just b -> pure (Char.chr b)
+                    Just b -> pure (b :: Word8)
                     Nothing -> fail $ "cannot read " ++ show sci
             bytes <- mapM (withScientific "byte" f) val
-            return $ ConstStr $ V.toList bytes
+            return $ ConstStr $ BS.pack bytes
 
         Just (String "bstr") -> do
             val <- v .: "val"

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -503,7 +503,7 @@ data FloatLit
 data ConstVal =
     ConstFloat FloatLit
   | ConstInt IntLit
-  | ConstStr String
+  | ConstStr B.ByteString
   | ConstByteStr B.ByteString
   | ConstBool Bool
   | ConstChar Char

--- a/src/Mir/PP.hs
+++ b/src/Mir/PP.hs
@@ -315,7 +315,7 @@ instance Pretty Substs where
 instance Pretty ConstVal where
     pretty (ConstFloat i)   = pretty i
     pretty (ConstInt i)     = pretty i
-    pretty (ConstStr i)     = char '\"' <> pretty i <> char '\"'
+    pretty (ConstStr i)     = char '\"' <> text (show i) <> char '\"'
     pretty (ConstByteStr i) = text (show i)
     pretty (ConstBool i)    = pretty i
     pretty (ConstChar i)    = pretty i

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -53,7 +53,6 @@ import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 import qualified Data.Vector as V
 import Data.String (fromString)
 import Numeric

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -1083,6 +1083,16 @@ assignVarExp v@(M.Var _vnamd _ (M.TyRef (M.TySlice _lhs_ty) M.Immut) _ _ _pos)
                     (Ctx.Empty Ctx.:> vec Ctx.:> start Ctx.:> len)
             assignVarExp v (MirExp (MirImmSliceRepr e_ty) struct)
 
+assignVarExp v@(M.Var _vnamd _ (M.TyRef M.TyStr M.Immut) _ _ _pos)
+               (MirExp (MirSliceRepr e_ty) e) =
+
+         do let rvec  = S.getStruct Ctx.i1of3 e
+            let start = S.getStruct Ctx.i2of3 e
+            let len   = S.getStruct Ctx.i3of3 e
+            vec <- readMirRef (C.VectorRepr e_ty) rvec
+            let struct = S.mkStruct (mirImmSliceCtxRepr e_ty)
+                    (Ctx.Empty Ctx.:> vec Ctx.:> start Ctx.:> len)
+            assignVarExp v (MirExp (MirImmSliceRepr e_ty) struct)
 
 assignVarExp (M.Var vname _ vty _ _ pos) me@(MirExp e_ty e) = do
     vm <- use varMap

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -169,10 +169,9 @@ transConstVal (Some (UsizeRepr)) (M.ConstInt i) =
        return $ MirExp UsizeRepr (S.app $ usizeLit n)
 transConstVal (Some (IsizeRepr)) (ConstInt i) =
       return $ MirExp IsizeRepr (S.app $ isizeLit (fromIntegerLit i))
-transConstVal (Some (MirImmSliceRepr (C.BVRepr w))) (M.ConstStr str)
+transConstVal (Some (MirImmSliceRepr (C.BVRepr w))) (M.ConstStr bs)
   | Just Refl <- testEquality w (knownNat @8) = do
     let u8Repr = C.BVRepr $ knownNat @8
-    let bs = Text.encodeUtf8 $ Text.pack str
     let bytes = map (\b -> R.App (E.BVLit (knownNat @8) (toInteger b))) (BS.unpack bs)
     let vec = R.App $ E.VectorLit u8Repr (V.fromList bytes)
     let start = R.App $ usizeLit 0

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -567,13 +567,10 @@ evalCast' ck ty1 e ty2  =
       (M.Misc, M.TyInt _,  M.TyInt s)  -> baseSizeToNatCont s $ extendSignedBV e
 
       -- unsigned to signed (nothing to do except fix sizes)
-      (M.Misc, M.TyUint _, M.TyInt s) -> baseSizeToNatCont s $ extendUnsignedBV e
+      (M.Misc, M.TyUint _, M.TyInt s)  -> baseSizeToNatCont s $ extendUnsignedBV e
 
-      -- signed to unsigned (TODO: check for negative numbers)
-      (M.Misc, M.TyInt s1,  M.TyUint s2)
-        | s1 == s2 -> return e      -- Reinterpret the bitvector as a different signedness
-        | otherwise -> mirFail
-          "unimplemented: cast changes signedness and size simultaneously"
+      -- signed to unsigned.  Testing indicates that this sign-extends.
+      (M.Misc, M.TyInt _,  M.TyUint s) -> baseSizeToNatCont s $ extendSignedBV e
 
        -- boolean to nat
       (M.Misc, TyBool, TyUint M.USize)

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -596,6 +596,12 @@ evalCast' ck ty1 e ty2  =
        -> baseSizeToNatCont bsz $ \w -> 
            return $ MirExp (C.BVRepr w) (R.App $ E.BVIte e0 w (R.App $ E.BVLit w 1) (R.App $ E.BVLit w 0))
 
+      -- char to uint
+      (M.Misc, M.TyChar, M.TyUint  M.USize)
+       | MirExp (C.BVRepr sz) e0 <- e
+       -> return $ MirExp UsizeRepr (bvToUsize sz R.App e0)
+      (M.Misc, M.TyChar, M.TyUint s) -> baseSizeToNatCont s $ extendUnsignedBV e
+
 
 
 

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -332,7 +332,7 @@ vector_copy_from_slice = ( ["crucible","vector","{{impl}}", "copy_from_slice"], 
 -- Methods for crucible::any::Any (which has custom representation)
 
 any_new :: (ExplodedDefId, CustomRHS)
-any_new = ( ["crucible", "any", "{{impl}}", "new"], \substs -> case substs of
+any_new = ( ["core", "crucible", "any", "{{impl}}", "new"], \substs -> case substs of
     Substs [_] -> Just $ CustomOp $ \_ ops -> case ops of
         [MirExp tpr e] -> do
             return $ MirExp C.AnyRepr $ R.App $ E.PackAny tpr e
@@ -341,7 +341,7 @@ any_new = ( ["crucible", "any", "{{impl}}", "new"], \substs -> case substs of
     )
 
 any_downcast :: (ExplodedDefId, CustomRHS)
-any_downcast = ( ["crucible", "any", "{{impl}}", "downcast"], \substs -> case substs of
+any_downcast = ( ["core", "crucible", "any", "{{impl}}", "downcast"], \substs -> case substs of
     Substs [t] -> Just $ CustomOp $ \_ ops -> case ops of
         [MirExp C.AnyRepr e]
           | Some tpr <- tyToRepr t -> do

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -118,9 +118,6 @@ customOpDefs = Map.fromList $ [
                          , vector_split_at
                          , vector_copy_from_slice
 
-                         , str_len
-
-
                          , exit
                          , abort
                          , panicking_begin_panic
@@ -631,24 +628,6 @@ slice_to_array = (["core","array", "slice_to_array"],
     )
 
 
-
-
-
--------------------------------------------------------------------------------------------------------
--- ** Custom: string operations
---
-str_len :: (ExplodedDefId, CustomRHS)
-str_len =
-  (["core","str","{{impl}}", "len"]
-  , \subs -> case subs of
-               (Substs []) -> Just $ CustomOp $ \ _optys  ops -> 
-                 case ops of 
-                    -- type of the structure is &str == TyStr ==> C.VectorRepr BV32
-                   [MirExp (C.VectorRepr _) vec_e] -> do
-                        return (MirExp UsizeRepr  (G.App $ vectorSizeUsize R.App vec_e))
-                   _ -> mirFail $ "BUG: invalid arguments to " ++ "string len"
-
-               _ -> Nothing)
 
 
 -------------------------------------------------------------------------------------------------------

--- a/src/Mir/TransTy.hs
+++ b/src/Mir/TransTy.hs
@@ -116,8 +116,8 @@ pattern CTyBv128 = CTyBv CTyBvSize128
 pattern CTyBv256 = CTyBv CTyBvSize256
 pattern CTyBv512 = CTyBv CTyBvSize512
 
-pattern CTyAny <- M.TyAdt _ $(M.normDefIdPat "crucible::any::Any") (M.Substs [])
-  where CTyAny = M.TyAdt (M.textId "type::adt") (M.textId "crucible::any::Any") (M.Substs [])
+pattern CTyAny <- M.TyAdt _ $(M.normDefIdPat "core::crucible::any::Any") (M.Substs [])
+  where CTyAny = M.TyAdt (M.textId "type::adt") (M.textId "core::crucible::any::Any") (M.Substs [])
 
 
 -- These don't have custom representation, but are referenced in various

--- a/src/Mir/TransTy.hs
+++ b/src/Mir/TransTy.hs
@@ -116,6 +116,10 @@ pattern CTyBv128 = CTyBv CTyBvSize128
 pattern CTyBv256 = CTyBv CTyBvSize256
 pattern CTyBv512 = CTyBv CTyBvSize512
 
+pattern CTyAny <- M.TyAdt _ $(M.normDefIdPat "crucible::any::Any") (M.Substs [])
+  where CTyAny = M.TyAdt (M.textId "type::adt") (M.textId "crucible::any::Any") (M.Substs [])
+
+
 -- These don't have custom representation, but are referenced in various
 -- places.
 pattern CTyOption t <- M.TyAdt _ $(M.normDefIdPat "core::option::Option") (M.Substs [t])
@@ -137,6 +141,7 @@ tyToRepr t0 = case t0 of
   CTyBv512 -> Some $ C.BVRepr (knownNat :: NatRepr 512)
   CTyBox t -> tyToReprCont t $ \repr -> Some (MirReferenceRepr repr)
   CTyVector t -> tyToReprCont t $ \repr -> Some (C.VectorRepr repr)
+  CTyAny -> Some C.AnyRepr
 
   M.TyBool -> Some C.BoolRepr
   M.TyTuple [] -> Some C.UnitRepr

--- a/test/conc_eval/fnptr/call.rs
+++ b/test/conc_eval/fnptr/call.rs
@@ -1,0 +1,15 @@
+#![feature(custom_attribute)]
+
+fn f(x: i32) -> i32 {
+    x + 1
+}
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let p: fn(i32) -> i32 = f;
+    p(1)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/fnptr/custom.rs
+++ b/test/conc_eval/fnptr/custom.rs
@@ -1,0 +1,16 @@
+// FAIL: taking address of an overridden function
+#![feature(custom_attribute)]
+use core::mem;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let mut x = 1;
+    let mut y = 2;
+    let p: fn(&mut i32, &mut i32) = mem::swap;
+    p(&mut x, &mut y);
+    x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/fnptr/make.rs
+++ b/test/conc_eval/fnptr/make.rs
@@ -1,0 +1,15 @@
+#![feature(custom_attribute)]
+
+fn f(x: i32) -> i32 {
+    x + 1
+}
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let p: fn(i32) -> i32 = f;
+    0
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/format.rs
+++ b/test/conc_eval/str/format.rs
@@ -1,0 +1,11 @@
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> bool {
+    let s = format!("a{}c", 'β');
+    &s == "aβc"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/format_array.rs
+++ b/test/conc_eval/str/format_array.rs
@@ -1,0 +1,11 @@
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> bool {
+    let s = format!("{:?}", [1,2,3,4]);
+    &s == "[1, 2, 3, 4]"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/format_hex.rs
+++ b/test/conc_eval/str/format_hex.rs
@@ -1,0 +1,12 @@
+// FAIL: translation error with `slice.iter_mut().rev()`
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> bool {
+    let s = format!("a{:x}c", 123);
+    &s == "a7bc"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/format_int.rs
+++ b/test/conc_eval/str/format_int.rs
@@ -1,0 +1,11 @@
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> bool {
+    let s = format!("a{}c", 123);
+    &s == "a123c"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/format_struct.rs
+++ b/test/conc_eval/str/format_struct.rs
@@ -1,0 +1,17 @@
+#![feature(custom_attribute)]
+
+#[derive(Debug)]
+struct MyStruct {
+    x: u8,
+    y: u8,
+}
+
+#[crux_test]
+fn crux_test() -> bool {
+    let s = format!("{:?}", MyStruct { x: 1, y: 2 });
+    &s == "MyStruct { x: 1, y: 2 }"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/string_push.rs
+++ b/test/conc_eval/str/string_push.rs
@@ -1,0 +1,14 @@
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> bool {
+    let mut s = String::new();
+    s.push('a');
+    s.push('β');
+    s.push('c');
+    &s == "aβc"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/str/to_owned.rs
+++ b/test/conc_eval/str/to_owned.rs
@@ -1,0 +1,11 @@
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> bool {
+    let s = "aβc".to_owned();
+    &s == "aβc"
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/any/downcast.good
+++ b/test/symb_eval/any/downcast.good
@@ -1,0 +1,2 @@
+1
+[Crux] No goals to prove.

--- a/test/symb_eval/any/downcast.rs
+++ b/test/symb_eval/any/downcast.rs
@@ -1,0 +1,15 @@
+#![feature(custom_attribute)]
+
+extern crate crucible;
+use crucible::any::Any;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let x: i32 = 1;
+    let a = Any::new(x);
+    unsafe { a.downcast::<i32>() }
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/any/downcast.rs
+++ b/test/symb_eval/any/downcast.rs
@@ -1,4 +1,5 @@
 #![feature(custom_attribute)]
+#![feature(crucible_intrinsics)]
 
 extern crate crucible;
 use crucible::any::Any;

--- a/test/symb_eval/any/downcast_fail.good
+++ b/test/symb_eval/any/downcast_fail.good
@@ -1,3 +1,3 @@
 [Crux] Disproved 1 out of 1 goals. 0 goals are unknown.
 [Crux] Failure for failed to downcast Any as BVRepr 32
-in downcast_fail/3a1fbbbh::crux_test[0] at test/symb_eval/any/downcast_fail.rs:10:5
+in downcast_fail/3a1fbbbh::crux_test[0] at test/symb_eval/any/downcast_fail.rs:11:14

--- a/test/symb_eval/any/downcast_fail.good
+++ b/test/symb_eval/any/downcast_fail.good
@@ -1,0 +1,3 @@
+[Crux] Disproved 1 out of 1 goals. 0 goals are unknown.
+[Crux] Failure for failed to downcast Any as BVRepr 32
+in downcast_fail/3a1fbbbh::crux_test[0] at test/symb_eval/any/downcast_fail.rs:10:5

--- a/test/symb_eval/any/downcast_fail.rs
+++ b/test/symb_eval/any/downcast_fail.rs
@@ -1,0 +1,15 @@
+#![feature(custom_attribute)]
+
+extern crate crucible;
+use crucible::any::Any;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let x: () = ();
+    let a = Any::new(x);
+    unsafe { a.downcast::<i32>() }
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/any/downcast_fail.rs
+++ b/test/symb_eval/any/downcast_fail.rs
@@ -1,4 +1,5 @@
 #![feature(custom_attribute)]
+#![feature(crucible_intrinsics)]
 
 extern crate crucible;
 use crucible::any::Any;

--- a/test/symb_eval/fnptr/mux.good
+++ b/test/symb_eval/fnptr/mux.good
@@ -1,0 +1,2 @@
+2
+[Crux] No goals to prove.

--- a/test/symb_eval/fnptr/mux.rs
+++ b/test/symb_eval/fnptr/mux.rs
@@ -1,0 +1,27 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+fn f(x: i32) -> i32 {
+    x + 1
+}
+
+fn g(x: i32) -> i32 {
+    x - 1
+}
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let b = bool::symbolic("cond");
+    let p1: fn(i32) -> i32 = if b { f } else { g };
+    let p2: fn(i32) -> i32 = if b { g } else { f };
+    let x1 = p1(1);
+    let x2 = p2(1);
+    crucible_assert!(x1 == 0 || x1 == 2);
+    crucible_assert!(x2 == 0 || x2 == 2);
+    x1 + x2
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/translate_libs.sh
+++ b/translate_libs.sh
@@ -29,7 +29,7 @@ translate lib/libcore/lib.rs --crate-name core \
     --cfg from_str --cfg dec2flt \
     --cfg any_downcast \
     --cfg hash \
-    # --cfg fmt   # trouble with integer formatting in bounds check panics
+    --cfg fmt   # trouble with integer formatting in bounds check panics
 
 translate_2015 lib/compiler-builtins/src/lib.rs --crate-name compiler_builtins \
     --cfg 'feature="compiler-builtins"'


### PR DESCRIPTION
This branch adds support for string formatting, which we will eventually use for custom counterexample printing.  Along the way, it also:

 * Changes the representation of `&str` from `VectorType (BVType 32)`
   (Haskell-style strings) to `MirImmSlice (BVType 8)`.  This makes `&str` match the representation of `&[u8]`, as it does in normal Rust.  This also lets us implement a variety of `String` and `str` methods that were previously unsupported.

 * Fixes translation of function-pointer calls and some types of casts.

 * Exposes Crucible's `AnyType` to Rust, as `crucible::any::Any`.  We use this
   to reimplement the type erasure performed in the `core::fmt` module, which originally used `mem::transmute` in a way we don't support.

With this branch applied, we can now handle most uses of the `format!` and `format_args!` macros, at least in cases where the arguments are concrete.