### PR TITLE
Custom counterexample printing

### DIFF
--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -24,7 +24,7 @@ pub fn crucible_u64(name: &'static str) -> u64 { Symbolic::symbolic(name) }
 
 pub fn crucible_assert_impl(
     _cond: bool,
-    _cond_str: &'static str,
+    _cond_str: &str,
     _file: &'static str,
     _line: u32,
     _col: u32,
@@ -34,8 +34,23 @@ pub fn crucible_assert_impl(
 
 #[macro_export]
 macro_rules! crucible_assert {
-    ($e:expr) => {
-        $crate::crucible_assert_impl($e, stringify!($e), file!(), line!(), column!())
+    ($cond:expr) => {
+        $crate::crucible_assert!($cond, stringify!($cond))
+    };
+    ($cond:expr, $fmt:expr) => {
+        $crate::crucible_assert_impl($cond, $fmt, file!(), line!(), column!());
+    };
+    ($cond:expr, $fmt:expr, $($args:tt)*) => {
+        if !$cond {
+            $crate::crucible_assert_impl(
+                false,
+                // Can't use `let` here because `format_args` takes the address of temporaries.
+                &format!("{}", $crate::concretize(format_args!($fmt, $($args)*))),
+                file!(),
+                line!(),
+                column!(),
+            );
+        }
     };
 }
 

--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -72,3 +72,13 @@ macro_rules! crucible_assert_unreachable {
         unreachable!()
     }};
 }
+
+
+/// Make a symbolic value concrete.
+///
+/// This is intended for use in printing counterexamples, where the current execution path is
+/// terminated shortly after the `concretize()` call.  It's probably unwise to use this on paths
+/// that will later be joined with others.
+pub fn concretize<T>(x: T) -> T {
+    x
+}

--- a/mir-verifier.cabal
+++ b/mir-verifier.cabal
@@ -17,6 +17,7 @@ library
   default-language: Haskell2010
   build-depends: base >= 4.7 && < 5,
                  aeson,
+                 ansi-terminal,
                  ansi-wl-pprint,
                  bytestring,
                  text,

--- a/src/Mir/Overrides.hs
+++ b/src/Mir/Overrides.hs
@@ -13,32 +13,51 @@
 
 module Mir.Overrides (bindFn) where
 
-import Control.Lens ((%=))
+import Control.Lens ((^.), (%=), use)
+import Control.Monad
 import Control.Monad.IO.Class
 
 import qualified Data.ByteString as BS
 import qualified Data.Char as Char
 import Data.Map (Map, fromList)
 import qualified Data.Map as Map
-import Data.Vector(Vector)
-import qualified Data.Vector as V
-import Data.Word
-
-import Data.Parameterized.Context (pattern Empty, pattern (:>))
-import Data.Parameterized.NatRepr
-
 import Data.Semigroup
-
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import Data.Word
 
 import System.IO (hPutStrLn)
 
+import Data.Parameterized.Context (pattern Empty, pattern (:>))
+import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Parameterized.Map as MapF
+import Data.Parameterized.NatRepr
+import Data.Parameterized.Nonce(withIONonceGenerator, NonceGenerator)
+import Data.Parameterized.Some
+import Data.Parameterized.TraversableF
+import Data.Parameterized.TraversableFC
+
+import What4.Expr.GroundEval (GroundValue, GroundEvalFn(..))
+import What4.FunctionName (FunctionName, functionNameFromText)
+import What4.Interface
+import What4.LabeledPred (LabeledPred(..))
+import What4.Partial (PartExpr, pattern PE, pattern Unassigned)
+import What4.Protocol.Online
+    ( OnlineSolver, inNewFrame, solverEvalFuns , solverConn, check
+    , getUnsatCore , checkWithAssumptionsAndModel )
+import What4.Protocol.SMTWriter
+    ( mkFormula, assumeFormulaWithFreshName , assumeFormula
+    , smtExprGroundEvalFn )
+import What4.SatResult (SatResult(..))
+
 import Lang.Crucible.Analysis.Postdom (postdomInfo)
 import Lang.Crucible.Backend
-    ( AssumptionReason(..), IsBoolSolver, LabeledPred(..), addAssumption, assert
-    , addFailedAssertion )
+    ( AssumptionReason(..), IsBoolSolver, LabeledPred(..), addAssumption
+    , assert, getPathCondition, Assumption(..), addFailedAssertion )
+import Lang.Crucible.Backend.Online
 import Lang.Crucible.CFG.Core (CFG, cfgArgTypes, cfgHandle, cfgReturnType, lastReg)
 import Lang.Crucible.Simulator (SimErrorReason(..))
 import Lang.Crucible.Simulator.ExecutionTree
@@ -46,19 +65,15 @@ import Lang.Crucible.Simulator.OverrideSim
 import Lang.Crucible.Simulator.RegMap
 import Lang.Crucible.Simulator.RegValue
 import Lang.Crucible.Simulator.SimError
-
 import Lang.Crucible.Types
 
-import What4.FunctionName (FunctionName, functionNameFromText)
-import What4.Interface
+import Crux (SomeOnlineSolver(..))
+import Crux.Model (addVar, evalModel)
+import Crux.Types (Model(..), Vars(..), Vals(..), Entry(..))
 
-import Crux.Model (addVar)
-import Crux.Types (Model)
-
-import Mir.Intrinsics
 import Mir.DefId
+import Mir.Intrinsics
 
-import Debug.Trace
 
 getString :: forall sym. (IsSymExprBuilder sym) => sym -> RegValue sym (MirImmSlice (BVType 8)) -> Maybe Text
 getString _ (Empty :> RV mirVec :> RV startExpr :> RV lenExpr)
@@ -107,19 +122,112 @@ array_symbolic btpr = do
     RegMap (Empty :> nameReg) <- getOverrideArgs
     makeSymbolicVar nameReg $ BaseArrayRepr (Empty :> BaseUsizeRepr) btpr
 
+concretize ::
+  forall sym rtp tp .
+  (IsSymExprBuilder sym, IsExprBuilder sym, IsBoolSolver sym) =>
+  Maybe (SomeOnlineSolver sym) ->
+  OverrideSim (Model sym) sym MIR rtp (EmptyCtx ::> tp) tp (RegValue sym tp)
+concretize (Just SomeOnlineSolver) = do
+    (sym :: sym) <- getSymInterface
+
+    GroundEvalFn evalGround <- liftIO $ withSolverProcess sym $ \sp -> do
+        cond <- getPathCondition sym
+        result <- checkWithAssumptionsAndModel sp "concretize" [cond]
+        case result of
+            Sat f -> return f
+            _ -> addFailedAssertion sym $
+                GenericSimError "path is already unreachable"
+    let evalBase :: forall bt . BaseTypeRepr bt -> SymExpr sym bt -> IO (SymExpr sym bt)
+        evalBase btr v = evalGround v >>= groundExpr sym btr
+
+    RegMap (Empty :> RegEntry tpr val) <- getOverrideArgs
+    liftIO $ regEval sym evalBase tpr val
+concretize Nothing = fail "`concretize` requires an online solver backend"
+
+groundExpr :: (IsExprBuilder sym, IsBoolSolver sym) => sym ->
+    BaseTypeRepr tp -> GroundValue tp -> IO (SymExpr sym tp)
+groundExpr sym tpr v = case tpr of
+    BaseBoolRepr -> return $ if v then truePred sym else falsePred sym
+    BaseNatRepr -> natLit sym v
+    BaseIntegerRepr -> intLit sym v
+    BaseRealRepr -> realLit sym v
+    BaseBVRepr w -> bvLit sym w v
+    BaseComplexRepr -> mkComplexLit sym v
+    BaseStringRepr _ -> stringLit sym v
+    _ -> addFailedAssertion sym $ GenericSimError $
+        "groundExpr: conversion of " ++ show tpr ++ " is not yet implemented"
+
+regEval ::
+    forall sym tp .
+    (IsExprBuilder sym, IsBoolSolver sym) =>
+    sym ->
+    (forall bt. BaseTypeRepr bt -> SymExpr sym bt -> IO (SymExpr sym bt)) ->
+    TypeRepr tp ->
+    RegValue sym tp ->
+    IO (RegValue sym tp)
+regEval sym baseEval tpr v = go tpr v
+  where
+    go :: forall tp' . TypeRepr tp' -> RegValue sym tp' -> IO (RegValue sym tp')
+    go tpr v | AsBaseType btr <- asBaseType tpr = baseEval btr v
+    go (FloatRepr fi) v = pure v
+    go AnyRepr (AnyValue tpr v) = AnyValue tpr <$> go tpr v
+    go UnitRepr () = pure ()
+    go CharRepr c = pure c
+    go (FunctionHandleRepr args ret) v = goFnVal args ret v
+    go (MaybeRepr tpr) pe = goPartExpr tpr pe
+    go (VectorRepr tpr) vec = traverse (go tpr) vec
+    go (StructRepr ctx) v = Ctx.zipWithM go' ctx v
+    go (VariantRepr ctx) v = Ctx.zipWithM goVariantBranch ctx v
+    -- TODO: ReferenceRepr
+    -- TODO: WordMapRepr
+    -- TODO: RecursiveRepr
+    -- TODO: MirReferenceRepr (intrinsic)
+    go (MirVectorRepr tpr') vec = case vec of
+        MirVector_Vector v -> MirVector_Vector <$> go (VectorRepr tpr') v
+        MirVector_Array a
+          | AsBaseType btpr' <- asBaseType tpr' ->
+            MirVector_Array <$> go (UsizeArrayRepr btpr') a
+          | otherwise -> error "unreachable: MirVector_Array elem type is always a base type"
+    -- TODO: StringMapRepr
+    go tpr v = addFailedAssertion sym $ GenericSimError $
+        "evaluation of " ++ show tpr ++ " is not yet implemented"
+
+    go' :: forall tp' . TypeRepr tp' -> RegValue' sym tp' -> IO (RegValue' sym tp')
+    go' tpr (RV v) = RV <$> go tpr v
+
+    goFnVal :: forall args ret .
+        CtxRepr args -> TypeRepr ret -> FnVal sym args ret -> IO (FnVal sym args ret)
+    goFnVal args ret (ClosureFnVal fv tpr v) =
+        ClosureFnVal <$> goFnVal (args :> tpr) ret fv <*> pure tpr <*> go tpr v
+    goFnVal _ _ (HandleFnVal fh) = pure $ HandleFnVal fh
+
+    goPartExpr :: forall tp' . TypeRepr tp' ->
+        PartExpr (Pred sym) (RegValue sym tp') ->
+        IO (PartExpr (Pred sym) (RegValue sym tp'))
+    goPartExpr tpr Unassigned = pure Unassigned
+    goPartExpr tpr (PE p v) = PE <$> baseEval BaseBoolRepr p <*> go tpr v
+
+    goVariantBranch :: forall tp' . TypeRepr tp' ->
+        VariantBranch sym tp' -> IO (VariantBranch sym tp')
+    goVariantBranch tpr (VB pe) = VB <$> goPartExpr tpr pe
+
 bindFn ::
   forall args ret blocks sym rtp a r .
   (IsSymExprBuilder sym, IsExprBuilder sym, IsBoolSolver sym) =>
-  Text -> CFG MIR blocks args ret ->
+  Maybe (SomeOnlineSolver sym) -> Text -> CFG MIR blocks args ret ->
   OverrideSim (Model sym) sym MIR rtp a r ()
-bindFn name cfg
+bindFn symOnline name cfg
   | (normDefId "crucible::array::symbolic" <> "::_inst") `Text.isPrefixOf` name
   , Empty :> MirImmSliceRepr (BVRepr w) <- cfgArgTypes cfg
   , UsizeArrayRepr btpr <- cfgReturnType cfg
   , Just Refl <- testEquality w (knownNat @8)
   = bindFnHandle (cfgHandle cfg) $ UseOverride $
     mkOverride' "array::symbolic" (UsizeArrayRepr btpr) (array_symbolic btpr)
-bindFn fn cfg =
+  | (normDefId "crucible::concretize" <> "::_inst") `Text.isPrefixOf` name
+  , Empty :> tpr <- cfgArgTypes cfg
+  , Just Refl <- testEquality tpr (cfgReturnType cfg)
+  = bindFnHandle (cfgHandle cfg) $ UseOverride $ mkOverride' "concretize" tpr $ concretize symOnline
+bindFn _symOnline fn cfg =
   getSymInterface >>= \s ->
   case Map.lookup fn (overrides s) of
     Nothing ->

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -69,9 +69,8 @@ runCrux rustFile outHandle = do
                                         Crux.goalTimeout = Just 120,
                                         Crux.solver = "z3" } ,
                    Mir.defaultMirOptions)
-    let language = Mir.mirLanguage { Crux.initialize = \_ -> return options }
-    let outputConfig = Crux.OutputConfig False outHandle outHandle False
-    _exitCode <- Crux.mainWithOutputConfig outputConfig language
+    let ?outputConfig = Crux.OutputConfig False outHandle outHandle False
+    _exitCode <- Mir.runTests options
     return ()
 
 cruxOracleTest :: FilePath -> String -> (String -> IO ()) -> Assertion

--- a/test/symb_eval/concretize/array.good
+++ b/test/symb_eval/concretize/array.good
@@ -1,0 +1,3 @@
+(1, 2, 3)
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/array.rs
+++ b/test/symb_eval/concretize/array.rs
@@ -1,0 +1,25 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+use crucible::array::Array;
+
+#[crux_test]
+fn crux_test() -> (i32, i32, i32) {
+    let arr = Array::symbolic("arr");
+    let s = arr.as_slice(0, 3);
+    for i in 0..3 {
+        crucible_assume!(0 < s[i] && s[i] <= 10);
+    }
+    for i in 0..2 {
+        crucible_assume!(s[i + 1] > s[i]);
+    }
+    crucible_assume!(s[0] + s[1] + s[2] == 6);
+
+    let s = concretize(s);
+    (s[0], s[1], s[2])
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}
+

--- a/test/symb_eval/concretize/assert.good
+++ b/test/symb_eval/concretize/assert.good
@@ -1,0 +1,11 @@
+1
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.
+[Crux] Failure for MIR assertion at test/symb_eval/concretize/assert.rs:11:5:
+	100 + 157 == 1
+in assert/3a1fbbbh::crux_test[0] at <::crucible::crucible_assert macros>:12:18: 13:79

--- a/test/symb_eval/concretize/assert.rs
+++ b/test/symb_eval/concretize/assert.rs
@@ -1,0 +1,18 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let mut x = u8::symbolic("x");
+    let mut y = u8::symbolic("y");
+    crucible_assume!(x + y == 1);
+    if x > 1 { crucible_assume!(x == 100) }
+    crucible_assert!(x == 0 || x == 1, "{} + {} == {}", x, y, x + y);
+    concretize(x + y)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}
+

--- a/test/symb_eval/concretize/assert_ok.good
+++ b/test/symb_eval/concretize/assert_ok.good
@@ -1,0 +1,8 @@
+1
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/assert_ok.rs
+++ b/test/symb_eval/concretize/assert_ok.rs
@@ -1,0 +1,18 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let mut x = u8::symbolic("x");
+    let mut y = u8::symbolic("y");
+    crucible_assume!(x + y == 1);
+    crucible_assume!(x < 100 && y < 100);
+    crucible_assert!(x == 0 || x == 1, "{} + {} == {}", x, y, x + y);
+    concretize(x + y)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}
+

--- a/test/symb_eval/concretize/conc.good
+++ b/test/symb_eval/concretize/conc.good
@@ -1,0 +1,3 @@
+(1, 0)
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/conc.rs
+++ b/test/symb_eval/concretize/conc.rs
@@ -1,0 +1,21 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> (u8, u8) {
+    let mut x = u8::symbolic("x");
+    let mut y = u8::symbolic("y");
+    crucible_assume!(x < 100 && y < 100);   // prevent overflow in addition
+    crucible_assume!(x + y == 1);
+    crucible_assume!(x != 0);
+    let (x, y) = concretize((x, y));
+    crucible_assert!(x == 0 || x == 1);
+    crucible_assert!(y == 0 || y == 1);
+    (x, y)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}
+

--- a/test/symb_eval/concretize/no_conc.good
+++ b/test/symb_eval/concretize/no_conc.good
@@ -1,0 +1,8 @@
+(Symbolic BV, Symbolic BV)
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/no_conc.rs
+++ b/test/symb_eval/concretize/no_conc.rs
@@ -1,0 +1,21 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> (u8, u8) {
+    let mut x = u8::symbolic("x");
+    let mut y = u8::symbolic("y");
+    crucible_assume!(x < 100 && y < 100);   // prevent overflow in addition
+    crucible_assume!(x + y == 1);
+    crucible_assume!(x != 0);
+    //let (x, y) = concretize((x, y));
+    crucible_assert!(x == 0 || x == 1);
+    crucible_assert!(y == 0 || y == 1);
+    (x, y)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}
+

--- a/test/symb_eval/crypto/bytes.good
+++ b/test/symb_eval/crypto/bytes.good
@@ -8,16 +8,16 @@
 [Crux] Overall status: Invalid.
 [Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at test/symb_eval/crypto/bytes.rs:86:24
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 [Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at test/symb_eval/crypto/bytes.rs:86:24
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 [Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at test/symb_eval/crypto/bytes.rs:86:24
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 [Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at test/symb_eval/crypto/bytes.rs:86:24
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 [Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at test/symb_eval/crypto/bytes.rs:86:24
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/overrides/override2.good
+++ b/test/symb_eval/overrides/override2.good
@@ -8,4 +8,4 @@
 [Crux] Overall status: Invalid.
 [Crux] Failure for MIR assertion at test/symb_eval/overrides/override2.rs:10:5:
 	foo + 1 == foo
-in override2/3a1fbbbh::f[0] at test/symb_eval/overrides/override2.rs:10:22
+in override2/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/overrides/override5.good
+++ b/test/symb_eval/overrides/override5.good
@@ -8,4 +8,4 @@
 [Crux] Overall status: Invalid.
 [Crux] Failure for MIR assertion at test/symb_eval/overrides/override5.rs:11:5:
 	foo + 1 != 0
-in override5/3a1fbbbh::f[0] at test/symb_eval/overrides/override5.rs:11:22
+in override5/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/sym_bytes/construct.good
+++ b/test/symb_eval/sym_bytes/construct.good
@@ -8,4 +8,4 @@ Symbolic BV
 [Crux] Overall status: Invalid.
 [Crux] Failure for MIR assertion at test/symb_eval/sym_bytes/construct.rs:14:5:
 	sym2[0] == 0
-in construct/3a1fbbbh::crux_test[0] at test/symb_eval/sym_bytes/construct.rs:14:22
+in construct/3a1fbbbh::crux_test[0] at <::crucible::crucible_assert macros>:2:42: 2:62


### PR DESCRIPTION
This branch adds the `crucible::concretize` intrinsic, and uses it to implement custom counterexample printing for `crucible_assert!` failures.

The purpose of `concretize(x)` is to choose an arbitrary concrete instance of `x`, where `x` may contain symbolic expressions.  It first queries the online solver for a model that satisfies the current path condition, then traverses `x` to evaluate each symbolic expression in it under the model.

Given `concretize`, we can now redefine the `crucible_assert!` macro to produce code like this:

```Rust
fn test() {
    let (x, y) = <(u8, u8)>::symbolic("xy");
    crucible_assume!(x + y == 1);
    // crucible_assert!(x == 0 || x == 1, "bad addition: {} + {} == 1?", x, y);
    // Approximate expansion:
    if !(x == 0 || x == 1) {
        let (x, y) = concretize((x, y));
        panic!("bad addition: {} + {} == 1?", x, y);
    }
}
```

`concretize` will choose an arbitrary concrete counterexample to the assertion that `x == 0 || x == 1`.  The string formatting for the `panic!` message can then be evaluated concretely, producing a message like `"bad addition: 128 + 129 == 1?"`.  All of Rust's normal string formatting capabilities are available here, including printing of structs, tuples, and arrays.

The implementation of `concretize` requires Crux to expose to extensions the fact that it uses an online solver backend, which is implemented in GaloisInc/crucible#440.
