### PR TITLE
Add symbolic byte arrays

### DIFF
--- a/lib/crucible/array.rs
+++ b/lib/crucible/array.rs
@@ -1,0 +1,34 @@
+use core::marker::PhantomData;
+
+#[derive(Copy)]
+pub struct Array<T>(PhantomData<T>);
+
+// NB: `T: Copy`, not `T: Clone`.  Using `clone` would require us to know all populated indices of
+// the array, which we don't.
+impl<T: Copy> Clone for Array<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Array<T> {
+    /// Construct a new array, filled with zeros.
+    ///
+    /// While `T` is declared as unconstrained, it's actually required to have a `BaseType`
+    /// Crucible representation.  All primitive integer types, as well as the wider bitvectors in
+    /// `crucible::bitvector`, satisfy this requirement.
+    pub const fn zeroed() -> Array<T> {
+        Self::zeroed()
+    }
+}
+
+impl<T: Copy> Array<T> {
+    pub fn lookup(self, idx: usize) -> T {
+        unimplemented!()
+    }
+
+    pub fn update(self, idx: usize, x: T) -> Self {
+        unimplemented!()
+    }
+}
+

--- a/lib/crucible/array.rs
+++ b/lib/crucible/array.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use crate::symbolic::Symbolic;
 
 #[derive(Copy)]
 pub struct Array<T>(PhantomData<T>);
@@ -39,6 +40,16 @@ impl<T: Copy> Array<T> {
 
     pub fn as_mut_slice(&mut self, start: usize, len: usize) -> &mut [T] {
         unimplemented!("Array::as_mut_slice")
+    }
+}
+
+fn symbolic<T>(desc: &'static str) -> Array<T> {
+    unimplemented!("Array::symbolic")
+}
+
+impl<T> Symbolic for Array<T> {
+    fn symbolic(desc: &'static str) -> Array<T> {
+        symbolic(desc)
     }
 }
 

--- a/lib/crucible/array.rs
+++ b/lib/crucible/array.rs
@@ -4,8 +4,9 @@ use crate::symbolic::Symbolic;
 #[derive(Copy)]
 pub struct Array<T>(PhantomData<T>);
 
-// NB: `T: Copy`, not `T: Clone`.  Using `clone` would require us to know all populated indices of
-// the array, which we don't.
+// NB: `T: Copy`, not `T: Clone`.  We can't clone all the array elements (like `Vec<T>` does)
+// because we don't know which indices are populated.  All we can do is copy the whole array, which
+// copies all its elements, and thus is valid only when `T: Copy`.
 impl<T: Copy> Clone for Array<T> {
     fn clone(&self) -> Self {
         *self

--- a/lib/crucible/array.rs
+++ b/lib/crucible/array.rs
@@ -24,11 +24,21 @@ impl<T> Array<T> {
 
 impl<T: Copy> Array<T> {
     pub fn lookup(self, idx: usize) -> T {
-        unimplemented!()
+        unimplemented!("Array::lookup")
     }
 
     pub fn update(self, idx: usize, x: T) -> Self {
-        unimplemented!()
+        unimplemented!("Array::update")
+    }
+
+    /// Take a slice of this array.  Symbolic arrays have unbounded size, so the caller can request
+    /// any offset and bounds they want for the resulting slice.
+    pub fn as_slice(&self, start: usize, len: usize) -> &[T] {
+        unimplemented!("Array::as_slice")
+    }
+
+    pub fn as_mut_slice(&mut self, start: usize, len: usize) -> &mut [T] {
+        unimplemented!("Array::as_mut_slice")
     }
 }
 

--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -6,6 +6,7 @@ pub use core::crucible::any;
 pub mod array;
 pub mod bitvector;
 pub mod symbolic;
+pub mod sym_bytes;
 pub mod vector;
 
 pub use self::symbolic::Symbolic;

--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -3,6 +3,7 @@
 #![feature(crucible_intrinsics)]
 
 pub use core::crucible::any;
+pub mod array;
 pub mod bitvector;
 pub mod symbolic;
 pub mod vector;

--- a/lib/crucible/sym_bytes.rs
+++ b/lib/crucible/sym_bytes.rs
@@ -1,0 +1,33 @@
+use core::ops::{Deref, DerefMut};
+use crate::array::Array;
+
+pub struct SymBytes {
+    arr: Array<u8>,
+    len: usize,
+}
+
+impl SymBytes {
+    pub fn new(len: usize) -> SymBytes {
+        SymBytes {
+            arr: Array::zeroed(),
+            len,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl Deref for SymBytes {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        self.arr.as_slice(0, self.len)
+    }
+}
+
+impl DerefMut for SymBytes {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.arr.as_mut_slice(0, self.len)
+    }
+}

--- a/lib/crucible/sym_bytes.rs
+++ b/lib/crucible/sym_bytes.rs
@@ -1,5 +1,7 @@
 use core::ops::{Deref, DerefMut};
+use crate::crucible_assume;
 use crate::array::Array;
+use crate::symbolic::Symbolic;
 
 pub struct SymBytes {
     arr: Array<u8>,
@@ -7,11 +9,33 @@ pub struct SymBytes {
 }
 
 impl SymBytes {
-    pub fn new(len: usize) -> SymBytes {
+    /// Create a new byte array, filling slots `0 .. len` with zeros.
+    pub fn zeroed(len: usize) -> SymBytes {
         SymBytes {
             arr: Array::zeroed(),
             len,
         }
+    }
+
+    /// Create a new byte array, filling slots `0 .. len` with symbolic values.
+    ///
+    /// This is like the trait method `Symbolic::symbolic`, but takes an additional `len` argument.
+    pub fn symbolic(desc: &'static str, len: usize) -> SymBytes {
+        SymBytes {
+            arr: Array::symbolic(desc),
+            len,
+        }
+    }
+
+    /// Create a new byte array, filling slots `0 .. len` with symbolic values, and constraining
+    /// the result with `f`.
+    ///
+    /// This is like the trait method `Symbolic::symbolic`, but takes an additional `len` argument.
+    pub fn symbolic_where<F>(desc: &'static str, len: usize, f: F) -> SymBytes
+    where F: FnOnce(&Self) -> bool {
+        let s = Self::symbolic(desc, len);
+        crucible_assume!(f(&s));
+        s
     }
 
     pub fn len(&self) -> usize {

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -495,6 +495,18 @@ subjustRef ::
   MirGenerator h s ret (R.Expr MIR s (MirReferenceType tp))
 subjustRef tp ref = G.extensionStmt (MirSubjustRef tp ref)
 
+mirRef_vectorAsMirVector ::
+  C.TypeRepr tp ->
+  R.Expr MIR s (MirReferenceType (C.VectorType tp)) ->
+  MirGenerator h s ret (R.Expr MIR s (MirReferenceType (MirVectorType tp)))
+mirRef_vectorAsMirVector tpr ref = G.extensionStmt $ MirRef_VectorAsMirVector tpr ref
+
+mirRef_arrayAsMirVector ::
+  C.BaseTypeRepr btp ->
+  R.Expr MIR s (MirReferenceType (UsizeArrayType btp)) ->
+  MirGenerator h s ret (R.Expr MIR s (MirReferenceType (MirVectorType (C.BaseToType btp))))
+mirRef_arrayAsMirVector btpr ref = G.extensionStmt $ MirRef_ArrayAsMirVector btpr ref
+
 -----------------------------------------------------------------------
 
 

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -83,6 +83,7 @@ import           Data.Parameterized.Context
 import           Data.Parameterized.TraversableFC
 import           Data.Parameterized.Peano
 import           Data.Parameterized.BoolRepr
+import           Data.Parameterized.NatRepr
 
 import qualified Lang.Crucible.FunctionHandle as FH
 import qualified Lang.Crucible.Types as C
@@ -549,6 +550,13 @@ vectorDrop ::
   R.Expr MIR s C.NatType ->
   MirGenerator h s ret (R.Expr MIR s (C.VectorType tp))
 vectorDrop tp v e = G.extensionStmt $ VectorDrop tp v e
+
+arrayZeroed ::
+  (1 <= w) =>
+  Assignment C.BaseTypeRepr (idxs ::> idx) ->
+  NatRepr w ->
+  MirGenerator h s ret (R.Expr MIR s (C.SymbolicArrayType (idxs ::> idx) (C.BaseBVType w)))
+arrayZeroed idxs w = G.extensionStmt $ ArrayZeroed idxs w
 
 
 

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -559,6 +559,34 @@ arrayZeroed ::
 arrayZeroed idxs w = G.extensionStmt $ ArrayZeroed idxs w
 
 
+mirVector_fromVector ::
+    C.TypeRepr tp ->
+    R.Expr MIR s (C.VectorType tp) ->
+    MirGenerator h s ret (R.Expr MIR s (MirVectorType tp))
+mirVector_fromVector tpr v = G.extensionStmt $ MirVector_FromVector tpr v
+
+mirVector_fromArray ::
+    C.BaseTypeRepr btp ->
+    R.Expr MIR s (UsizeArrayType btp) ->
+    MirGenerator h s ret (R.Expr MIR s (MirVectorType (C.BaseToType btp)))
+mirVector_fromArray tpr a = G.extensionStmt $ MirVector_FromArray tpr a
+
+mirVector_lookup ::
+    C.TypeRepr tp ->
+    R.Expr MIR s (MirVectorType tp) ->
+    R.Expr MIR s UsizeType ->
+    MirGenerator h s ret (R.Expr MIR s tp)
+mirVector_lookup tpr v i = G.extensionStmt $ MirVector_Lookup tpr v i
+
+mirVector_update ::
+    C.TypeRepr tp ->
+    R.Expr MIR s (MirVectorType tp) ->
+    R.Expr MIR s UsizeType ->
+    R.Expr MIR s tp ->
+    MirGenerator h s ret (R.Expr MIR s (MirVectorType tp))
+mirVector_update tpr v i x = G.extensionStmt $ MirVector_Update tpr v i x
+
+
 
 
 --  LocalWords:  ty ImplementTrait ctx vtable idx runtime struct

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -484,7 +484,7 @@ subvariantRef ctx ref idx = G.extensionStmt (MirSubvariantRef ctx ref idx)
 
 subindexRef ::
   C.TypeRepr tp ->
-  R.Expr MIR s (MirReferenceType (C.VectorType tp)) ->
+  R.Expr MIR s (MirReferenceType (MirVectorType tp)) ->
   R.Expr MIR s UsizeType ->
   MirGenerator h s ret (R.Expr MIR s (MirReferenceType tp))
 subindexRef tp ref idx = G.extensionStmt (MirSubindexRef tp ref idx)

--- a/src/Mir/Overrides.hs
+++ b/src/Mir/Overrides.hs
@@ -52,7 +52,7 @@ import What4.Interface
 import Crux.Model (addVar)
 import Crux.Types (Model)
 
-import Mir.Intrinsics (MIR, MirImmSlice, pattern MirImmSliceRepr)
+import Mir.Intrinsics (MIR, SizeBits, MirImmSlice, pattern MirImmSliceRepr)
 import Mir.DefId
 
 import Debug.Trace
@@ -72,7 +72,6 @@ getString _ (Empty :> RV vec :> RV startExpr :> RV lenExpr) = do
 
 data SomeOverride p sym where
   SomeOverride :: CtxRepr args -> TypeRepr ret -> Override p sym MIR args ret -> SomeOverride p sym
-
 
 bindFn ::
   forall args ret blocks sym rtp a r .

--- a/src/Mir/Overrides.hs
+++ b/src/Mir/Overrides.hs
@@ -205,20 +205,4 @@ bindFn fn cfg =
                        let reason = AssumptionReason loc $ "Assumption \n\t" <> src <> "\nfrom " <> locStr
                        liftIO $ addAssumption s (LabeledPred (regValue c) reason)
                        return ()
-               , override "crucible::array::symbolic" (Empty :> strrepr) (UsizeArrayRepr (BaseBVRepr (knownNat @8))) $ do
-                    RegMap (Empty :> str) <- getOverrideArgs
-                    let sym = (undefined :: sym)
-                    x <- maybe (fail "not a constant string") pure (getString sym (regValue str))
-                    let xStr = Text.unpack x
-                    let y = filter ((/=) '\"') xStr
-                    nname <-
-                      case userSymbol y of
-                        Left err -> fail (show err ++ " " ++ y)
-                        Right a -> return a
-                    s <- getSymInterface
-                    let btpr = BaseArrayRepr (Empty :> BaseUsizeRepr) (BaseBVRepr (knownNat @8))
-                    v <- liftIO (freshConstant s nname btpr)
-                    loc   <- liftIO $ getCurrentProgramLoc s
-                    stateContext.cruciblePersonality %= addVar loc xStr btpr v
-                    return v
                ]

--- a/src/Mir/Overrides.hs
+++ b/src/Mir/Overrides.hs
@@ -52,13 +52,14 @@ import What4.Interface
 import Crux.Model (addVar)
 import Crux.Types (Model)
 
-import Mir.Intrinsics (MIR, SizeBits, MirImmSlice, pattern MirImmSliceRepr)
+import Mir.Intrinsics (MIR, SizeBits, MirImmSlice, pattern MirImmSliceRepr, MirVector(..))
 import Mir.DefId
 
 import Debug.Trace
 
 getString :: forall sym. (IsSymExprBuilder sym) => sym -> RegValue sym (MirImmSlice (BVType 8)) -> Maybe Text
-getString _ (Empty :> RV vec :> RV startExpr :> RV lenExpr) = do
+getString _ (Empty :> RV mirVec :> RV startExpr :> RV lenExpr)
+  | MirVector_Vector vec <- mirVec = do
     start <- asUnsignedBV startExpr
     len <- asUnsignedBV lenExpr
     let slice = V.slice (fromInteger start) (fromInteger len) vec
@@ -69,6 +70,7 @@ getString _ (Empty :> RV vec :> RV startExpr :> RV lenExpr) = do
                       Nothing -> Nothing
     bs <- BS.pack <$> mapM f (V.toList slice)
     return $ Text.decodeUtf8 bs
+  | otherwise = Nothing
 
 data SomeOverride p sym where
   SomeOverride :: CtxRepr args -> TypeRepr ret -> Override p sym MIR args ret -> SomeOverride p sym

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -173,11 +173,12 @@ transConstVal (Some (MirImmSliceRepr (C.BVRepr w))) (M.ConstStr bs)
     let u8Repr = C.BVRepr $ knownNat @8
     let bytes = map (\b -> R.App (E.BVLit (knownNat @8) (toInteger b))) (BS.unpack bs)
     let vec = R.App $ E.VectorLit u8Repr (V.fromList bytes)
+    mirVec <- mirVector_fromVector u8Repr vec
     let start = R.App $ usizeLit 0
     let len = R.App $ usizeLit $ fromIntegral $ BS.length bs
     let struct = S.mkStruct
             knownRepr
-            (Ctx.Empty Ctx.:> vec Ctx.:> start Ctx.:> len)
+            (Ctx.Empty Ctx.:> mirVec Ctx.:> start Ctx.:> len)
     return $ MirExp (MirImmSliceRepr u8Repr) struct
 transConstVal (Some (C.VectorRepr w)) (M.ConstArray arr)
       | Just Refl <- testEquality w (C.BVRepr (knownRepr :: NatRepr 8))
@@ -614,9 +615,10 @@ evalCast' ck ty1 e ty2  =
         | tp == tp', MirExp (C.VectorRepr elem_tp) ref <- e
         -> do let start = R.App $ usizeLit 0
               let len   = R.App $ usizeLit (fromIntegral sz)
+              vec <- mirVector_fromVector elem_tp ref
               let tup   = S.mkStruct
-                              (Ctx.Empty Ctx.:> C.VectorRepr elem_tp Ctx.:> UsizeRepr Ctx.:> UsizeRepr)
-                              (Ctx.Empty Ctx.:> ref Ctx.:> start Ctx.:> len)
+                              (Ctx.Empty Ctx.:> MirVectorRepr elem_tp Ctx.:> UsizeRepr Ctx.:> UsizeRepr)
+                              (Ctx.Empty Ctx.:> vec Ctx.:> start Ctx.:> len)
               return $ MirExp (MirImmSliceRepr elem_tp) tup
         | otherwise -> mirFail $ "Type mismatch in cast: " ++ show ck ++ " " ++ show ty1 ++ " as " ++ show ty2
 
@@ -629,9 +631,10 @@ evalCast' ck ty1 e ty2  =
         | tp == tp', MirExp (MirReferenceRepr (C.VectorRepr elem_tp)) ref <- e
         -> do let start = R.App $ usizeLit 0
               let len   = R.App $ usizeLit (fromIntegral sz)
+              vecRef <- mirRef_vectorAsMirVector elem_tp ref
               let tup   = S.mkStruct
-                              (Ctx.Empty Ctx.:> MirReferenceRepr (C.VectorRepr elem_tp) Ctx.:> UsizeRepr Ctx.:> UsizeRepr)
-                              (Ctx.Empty Ctx.:> ref Ctx.:> start Ctx.:> len)
+                              (Ctx.Empty Ctx.:> MirReferenceRepr (MirVectorRepr elem_tp) Ctx.:> UsizeRepr Ctx.:> UsizeRepr)
+                              (Ctx.Empty Ctx.:> vecRef Ctx.:> start Ctx.:> len)
               return $ MirExp (MirSliceRepr elem_tp) tup
         | otherwise -> mirFail $ "Type mismatch in cast: " ++ show ck ++ " " ++ show ty1 ++ " as " ++ show ty2
 
@@ -807,7 +810,8 @@ evalRefProj base projElem =
             | C.VectorRepr tp' <- elty
             , fromend == False ->
                 do let natIdx = R.App $ usizeLit (fromIntegral offset)
-                   r' <- subindexRef tp' ref natIdx
+                   ref' <- mirRef_vectorAsMirVector tp' ref
+                   r' <- subindexRef tp' ref' natIdx
                    return (MirExp (MirReferenceRepr tp') r')
 
             | C.VectorRepr _tp' <- elty
@@ -816,14 +820,15 @@ evalRefProj base projElem =
 
           M.Index var
             | C.VectorRepr tp' <- elty
-            -> do MirExp idxTy idx <- lookupVar var
+            -> do ref' <- mirRef_vectorAsMirVector tp' ref
+                  MirExp idxTy idx <- lookupVar var
                   case idxTy of
                     UsizeRepr ->
-                      do r' <- subindexRef tp' ref idx
+                      do r' <- subindexRef tp' ref' idx
                          return (MirExp (MirReferenceRepr tp') r')
                     C.BVRepr w ->
                       do idxUsize <- G.forceEvaluation (bvToUsize w R.App idx)
-                         r' <- subindexRef tp' ref idxUsize
+                         r' <- subindexRef tp' ref' idxUsize
                          return (MirExp (MirReferenceRepr tp') r')
 
                     _ -> mirFail ("Expected index value to be an integer value in reference projection " ++
@@ -954,7 +959,7 @@ evalLvalue (M.LProj (M.LProj lv M.Deref) (M.Index i))
             G.assertExpr (R.App $ usizeLt ind len)
                 (S.litExpr "index out of range (for access to &[_])")
             let ind' = R.App $ usizeAdd start ind
-            return $ MirExp elt_tp $ R.App $ vectorGetUsize elt_tp R.App vec ind'
+            MirExp elt_tp <$> mirVector_lookup elt_tp vec ind'
         _ -> mirFail $ "bad types for immutable slice indexing: " ++ show (arr_tp, ind_tp)
   | M.TyRef (M.TySlice _) M.Mut <- M.typeOf lv = do
     MirExp arr_tp arr <- evalLvalue lv
@@ -962,13 +967,13 @@ evalLvalue (M.LProj (M.LProj lv M.Deref) (M.Index i))
     case (arr_tp, ind_tp) of
         (MirSliceRepr elt_tp, UsizeRepr) -> do
             let vecRef = S.getStruct Ctx.i1of3 arr
-            vec <- readMirRef (C.VectorRepr elt_tp) vecRef
+            vec <- readMirRef (MirVectorRepr elt_tp) vecRef
             let start = S.getStruct Ctx.i2of3 arr
             let len = S.getStruct Ctx.i3of3 arr
             G.assertExpr (R.App $ usizeLt ind len)
                 (S.litExpr "index out of range (for access to &mut [_])")
             let ind' = R.App $ usizeAdd start ind
-            return $ MirExp elt_tp $ R.App $ vectorGetUsize elt_tp R.App vec ind'
+            MirExp elt_tp <$> mirVector_lookup elt_tp vec ind'
         _ -> mirFail $ "bad types for mutable slice indexing: " ++ show (arr_tp, ind_tp)
 
 evalLvalue (M.LProj lv (M.Index i)) = do
@@ -1074,7 +1079,7 @@ assignVarExp v@(M.Var _vnamd _ (M.TyRef (M.TySlice _lhs_ty) M.Immut) _ _ _pos)
          do let rvec  = S.getStruct Ctx.i1of3 e
             let start = S.getStruct Ctx.i2of3 e
             let len   = S.getStruct Ctx.i3of3 e
-            vec <- readMirRef (C.VectorRepr e_ty) rvec
+            vec <- readMirRef (MirVectorRepr e_ty) rvec
             let struct = S.mkStruct (mirImmSliceCtxRepr e_ty)
                     (Ctx.Empty Ctx.:> vec Ctx.:> start Ctx.:> len)
             assignVarExp v (MirExp (MirImmSliceRepr e_ty) struct)
@@ -1085,7 +1090,7 @@ assignVarExp v@(M.Var _vnamd _ (M.TyRef M.TyStr M.Immut) _ _ _pos)
          do let rvec  = S.getStruct Ctx.i1of3 e
             let start = S.getStruct Ctx.i2of3 e
             let len   = S.getStruct Ctx.i3of3 e
-            vec <- readMirRef (C.VectorRepr e_ty) rvec
+            vec <- readMirRef (MirVectorRepr e_ty) rvec
             let struct = S.mkStruct (mirImmSliceCtxRepr e_ty)
                     (Ctx.Empty Ctx.:> vec Ctx.:> start Ctx.:> len)
             assignVarExp v (MirExp (MirImmSliceRepr e_ty) struct)
@@ -1151,14 +1156,13 @@ assignLvExp lv re = do
                case (slice_tp, ind_tp) of
                  (MirSliceRepr el_tp, UsizeRepr)
                    | Just Refl <- testEquality r_tp el_tp
-                   -> do let _ctx   = Ctx.Empty Ctx.:> MirReferenceRepr (C.VectorRepr el_tp) Ctx.:> UsizeRepr Ctx.:> UsizeRepr
-                         let ref   = S.getStruct (Ctx.natIndex @0) slice
+                   -> do let ref   = S.getStruct (Ctx.natIndex @0) slice
                          let start = S.getStruct (Ctx.natIndex @1) slice
                          let len   = S.getStruct (Ctx.natIndex @2) slice
                          G.assertExpr (R.App $ usizeLt ind len) (S.litExpr "Index out of range")
                          let ind'  = R.App $ usizeAdd start ind
-                         arr <- readMirRef (C.VectorRepr el_tp) ref
-                         let arr' = S.app $ vectorSetUsize el_tp R.App arr ind' r
+                         arr <- readMirRef (MirVectorRepr el_tp) ref
+                         arr' <- mirVector_update el_tp arr ind' r
                          writeMirRef ref arr'
 
                  _ -> mirFail $ "bad type in slice assignment"
@@ -1602,25 +1606,27 @@ initialValue (M.TyArray t size) = do
       Nothing -> return Nothing
 initialValue (M.TyRef (M.TySlice t) M.Immut) = do
     tyToReprCont t $ \ tr -> do
-      let vec = MirExp (C.VectorRepr tr) $ R.App $ E.VectorLit tr V.empty
-      let i = (MirExp UsizeRepr (R.App $ usizeLit 0))
-      return $ Just $ buildTuple [vec, i, i]
+      let vec = R.App $ E.VectorLit tr V.empty
+      vec' <- MirExp (MirVectorRepr tr) <$> mirVector_fromVector tr vec
+      let i = MirExp UsizeRepr (R.App $ usizeLit 0)
+      return $ Just $ buildTuple [vec', i, i]
 initialValue (M.TyRef (M.TySlice t) M.Mut) = do
     tyToReprCont t $ \ tr -> do
-      ref <- newMirRef (C.VectorRepr tr)      
-      let i = (MirExp UsizeRepr (R.App $ usizeLit 0))
-      return $ Just $ buildTuple [(MirExp (MirReferenceRepr (C.VectorRepr tr)) ref), i, i]
+      ref <- newMirRef (MirVectorRepr tr)
+      let i = MirExp UsizeRepr (R.App $ usizeLit 0)
+      return $ Just $ buildTuple [(MirExp (MirReferenceRepr (MirVectorRepr tr)) ref), i, i]
       -- fail ("don't know how to initialize slices for " ++ show t)
 initialValue (M.TyRef M.TyStr M.Immut) = do
     let tr = C.BVRepr $ knownNat @8
-    let vec = MirExp (C.VectorRepr tr) $ R.App $ E.VectorLit tr V.empty
-    let i = (MirExp UsizeRepr (R.App $ usizeLit 0))
-    return $ Just $ buildTuple [vec, i, i]
+    let vec = R.App $ E.VectorLit tr V.empty
+    vec' <- MirExp (MirVectorRepr tr) <$> mirVector_fromVector tr vec
+    let i = MirExp UsizeRepr (R.App $ usizeLit 0)
+    return $ Just $ buildTuple [vec', i, i]
 initialValue (M.TyRef M.TyStr M.Mut) = do
     let tr = C.BVRepr $ knownNat @8
-    ref <- newMirRef (C.VectorRepr tr)
-    let i = (MirExp UsizeRepr (R.App $ usizeLit 0))
-    return $ Just $ buildTuple [(MirExp (MirReferenceRepr (C.VectorRepr tr)) ref), i, i]
+    ref <- newMirRef (MirVectorRepr tr)
+    let i = MirExp UsizeRepr (R.App $ usizeLit 0)
+    return $ Just $ buildTuple [(MirExp (MirReferenceRepr (MirVectorRepr tr)) ref), i, i]
 initialValue (M.TyRef (M.TyDynamic _ _) _) = do
     let x = R.App $ E.PackAny knownRepr $ R.App $ E.EmptyApp
     return $ Just $ MirExp knownRepr $ R.App $ E.MkStruct knownRepr $
@@ -2380,15 +2386,15 @@ transStatics colState halloc = do
 
 
 --
--- Generate a loop that copies a vector  
+-- Generate a loop that copies a MirVector into a Vector.
 -- 
 vectorCopy :: C.TypeRepr elt ->
              G.Expr MIR s UsizeType ->
              G.Expr MIR s UsizeType ->
-             G.Expr MIR s (C.VectorType elt) ->
+             G.Expr MIR s (MirVectorType elt) ->
              MirGenerator h s ret (G.Expr MIR s (C.VectorType elt))
 vectorCopy ety start stop inp = do
-  let elt = S.app $ vectorGetUsize ety R.App inp (S.app $ usizeLit 0)
+  elt <- mirVector_lookup ety inp (S.app $ usizeLit 0)
   let sz  = S.app $ usizeSub stop start
   let out = S.app $ E.VectorReplicate ety (R.App $ usizeToNat sz) elt
   ir <- G.newRef start
@@ -2397,7 +2403,7 @@ vectorCopy ety start stop inp = do
   G.while (pos, do i <- G.readRef ir
                    return (G.App $ usizeLt i stop))
           (pos, do i <- G.readRef ir
-                   let elt = S.app $ vectorGetUsize ety R.App inp i
+                   elt <- mirVector_lookup ety inp i
                    o   <- G.readRef or
                    let j = (G.App $ usizeSub i start)
                    let o' = S.app $ vectorSetUsize ety R.App o j elt

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -1572,6 +1572,12 @@ initialValue (CTyBox t) = do
 initialValue (CTyVector t) = do
     tyToReprCont t $ \ tr ->
       return $ Just (MirExp (C.VectorRepr tr) (S.app $ E.VectorLit tr V.empty))
+initialValue (CTyArray t) = case tyToRepr t of
+    Some (C.BVRepr w) -> do
+        let idxs = Ctx.Empty Ctx.:> BaseUsizeRepr
+        v <- arrayZeroed idxs w
+        return $ Just $ MirExp (C.SymbolicArrayRepr idxs (C.BaseBVRepr w)) v
+    _ -> error $ "can't initialize array of " ++ show t ++ " (expected BVRepr)"
 initialValue ty@(CTyBv _sz)
   | Some (C.BVRepr w) <- tyToRepr ty
   = return $ Just $ MirExp (C.BVRepr w) $ S.app $ E.BVLit w 0

--- a/test/symb_eval/array/basic.good
+++ b/test/symb_eval/array/basic.good
@@ -1,0 +1,3 @@
+3
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/test/symb_eval/array/basic.rs
+++ b/test/symb_eval/array/basic.rs
@@ -1,0 +1,16 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::array::Array;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let arr = Array::<i32>::zeroed();
+    let arr = arr.update(0, 0);
+    let arr = arr.update(1, 1);
+    let arr = arr.update(2, 2);
+    arr.lookup(0) + arr.lookup(1) + arr.lookup(2) + arr.lookup(99)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/array/mux_slice.good
+++ b/test/symb_eval/array/mux_slice.good
@@ -1,0 +1,8 @@
+Symbolic BV
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Valid.

--- a/test/symb_eval/array/mux_slice.rs
+++ b/test/symb_eval/array/mux_slice.rs
@@ -1,0 +1,26 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::array::Array;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let mut arr1 = Array::<i32>::zeroed();
+    let mut arr2 = Array::<i32>::zeroed();
+    for i in 0..10 {
+        arr1 = arr1.update(i, i as i32);
+        arr2 = arr2.update(i, 9 - i as i32);
+    }
+
+    let s: &[i32] = if bool::symbolic("cond") {
+        arr1.as_slice(0, 10)
+    } else {
+        arr2.as_slice(0, 10)
+    };
+    crucible_assert!(s.iter().cloned().sum::<i32>() == 45);
+    s[5]
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/array/slice.good
+++ b/test/symb_eval/array/slice.good
@@ -1,0 +1,3 @@
+5
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/test/symb_eval/array/slice.rs
+++ b/test/symb_eval/array/slice.rs
@@ -1,0 +1,20 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::array::Array;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let mut arr = Array::<i32>::zeroed();
+    for i in 0..10 {
+        arr = arr.update(i, i as i32);
+    }
+    crucible_assert!(arr.as_slice(0, 10).iter().cloned().sum::<i32>() == 45);
+    crucible_assert!(arr.as_slice(0, 5).iter().cloned().sum::<i32>() == 10);
+    crucible_assert!(arr.as_slice(5, 10).iter().cloned().sum::<i32>() == 45 - 10);
+    arr.lookup(5)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/array/slice_mut.good
+++ b/test/symb_eval/array/slice_mut.good
@@ -1,0 +1,3 @@
+5
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/test/symb_eval/array/slice_mut.rs
+++ b/test/symb_eval/array/slice_mut.rs
@@ -1,0 +1,21 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::array::Array;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let mut arr = Array::<i32>::zeroed();
+    let xs = arr.as_mut_slice(0, 10);
+    for i in 0..10 {
+        xs[i] = i as i32;
+    }
+    for i in 0..10 {
+        crucible_assert!(arr.lookup(i) == i as i32);
+    }
+    arr.lookup(5)
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/overrides/bad_symb1.good
+++ b/test/symb_eval/overrides/bad_symb1.good
@@ -1,0 +1,9 @@
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.
+[Crux] Failure for symbolic variable name must be a concrete string
+in crucible/3a1fbbbh::symbolic[0]::{{impl}}[1]::symbolic[0] at lib/crucible/symbolic.rs:24:64

--- a/test/symb_eval/overrides/bad_symb1.rs
+++ b/test/symb_eval/overrides/bad_symb1.rs
@@ -1,0 +1,14 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let s = if bool::symbolic("cond") { "a" } else { "b" };
+    let x = u8::symbolic(s);
+    x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/overrides/bad_symb2.good
+++ b/test/symb_eval/overrides/bad_symb2.good
@@ -1,0 +1,9 @@
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.
+[Crux] Failure for invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
+in crucible/3a1fbbbh::symbolic[0]::{{impl}}[1]::symbolic[0] at lib/crucible/symbolic.rs:24:64

--- a/test/symb_eval/overrides/bad_symb2.rs
+++ b/test/symb_eval/overrides/bad_symb2.rs
@@ -1,0 +1,13 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let x = u8::symbolic("\0:., /");
+    x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/sym_bytes/construct.good
+++ b/test/symb_eval/sym_bytes/construct.good
@@ -1,0 +1,11 @@
+Symbolic BV
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.
+[Crux] Failure for MIR assertion at test/symb_eval/sym_bytes/construct.rs:14:5:
+	sym2[0] == 0
+in construct/3a1fbbbh::crux_test[0] at test/symb_eval/sym_bytes/construct.rs:14:22

--- a/test/symb_eval/sym_bytes/construct.rs
+++ b/test/symb_eval/sym_bytes/construct.rs
@@ -1,0 +1,20 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+use crucible::sym_bytes::SymBytes;
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let sym1 = SymBytes::zeroed(5);
+    // Should succeed - sym1[0] is zero.  In fact, this should get simplified away and not produce
+    // a solver goal at all.
+    crucible_assert!(sym1[0] == 0);
+    let sym2 = SymBytes::symbolic("sym", 5);
+    // Should fail - sym2[0] is arbitrary
+    crucible_assert!(sym2[0] == 0);
+    sym1[0] + sym2[0]
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/sym_bytes/deserialize.good
+++ b/test/symb_eval/sym_bytes/deserialize.good
@@ -1,0 +1,8 @@
+Symbolic BV
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Valid.

--- a/test/symb_eval/sym_bytes/deserialize.rs
+++ b/test/symb_eval/sym_bytes/deserialize.rs
@@ -1,0 +1,38 @@
+#![feature(custom_attribute)]
+extern crate crucible;
+use crucible::*;
+use crucible::sym_bytes::SymBytes;
+
+fn deserialize(b: &[u8]) -> (i16, i16) {
+    match b[0] {
+        0 => {
+            let x = b[1] as i16 | (b[2] as i16) << 8;
+            let y = b[3] as i16 | (b[4] as i16) << 8;
+            (x, y)
+        },
+        1 => {
+            let x = b[1] as i8 as i16;
+            let y = b[2] as i8 as i16;
+            (x, y)
+        },
+        2 => {
+            let x = b[1] as i16 | (b[2] as i16) << 8;
+            let y = x + (b[3] as i8 as i16);
+            (x, y)
+        },
+        _ => panic!("bad encoding kind"),
+    }
+}
+
+#[crux_test]
+fn crux_test() -> i32 {
+    let sym = SymBytes::symbolic("sym", 5);
+    crucible_assume!(sym[0] <= 2);
+
+    let (x, y) = deserialize(&sym);
+    x as i32 + y as i32
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}


### PR DESCRIPTION
This branch exposes symbolic byte arrays to Rust.  There are three main parts:

 1. Expose `SymbolicArrayType` to Rust as `crucible::array::Array<T>` (where `T` must be represented in Crucible by a what4 `BaseType`).  Crucible allows symbolic arrays to have multiple indices/dimensions, but we only expose arrays with a single index of type `usize`.  The element type can be any base type, though currently we only really use `u8` / `BaseBVType 8`.
 2. We'd like to take slices (`&[u8]`) of an `Array<u8>` that we can use as input/output buffers for existing de/serialization functions.  This is tricky because slices are currently always backed by Crucible `VectorType`, which is the representation type for Rust arrays (`[T; n]`) and vectors (`crucible::vector::Vector<T>` / `std::vec::Vec<T>`).  So this branch defines a new type `MirVectorType` that wraps an instance of either `VectorType` or `SymbolicArrayType`, and updates the slice representation to use it.  This allows implementing `as_slice` for `crucible::array::Array<T>`, producing slices that are interchangeable with ones derived from Rust arrays or vectors (as long as you don't try to mux together slices backed by `VectorType` with ones backed by `SymbolicArrayType`).
 3. Finally, this branch defines `crucible::sym_bytes::SymBytes`, which is an `Array<u8>` with finite length.  (`Array<T>`, like the underlying `SymbolicArrayType`, has unlimited size.)  `SymBytes` is meant to replace Rust arrays or fixed-length `Vec<u8>`s as a buffer for use with serialization code.  It implements `DerefMut<Target = [u8]>` and not much else.

Preliminary testing of `SymBytes` with some real-world serialization code shows 30-50% reduction in running time of the tests.

In the future, it should be fairly easy to allow `Vec<T>` to be backed by either `SymbolicArrayType` or `VectorType`, as this branch does for slices.  This would allow providing `SymbolicArrayType` buffers to serialization code that hardcodes `Vec<u8>` for its input or output buffers.  But so far, we haven't encountered any code that would require this.