### PR TITLE
Run and report tests separately

### DIFF
--- a/src/Mir/Language.hs
+++ b/src/Mir/Language.hs
@@ -223,9 +223,10 @@ runTests (cruxOpts, mirOpts) = do
         outputLn ""
         outputLn "failures:"
         forM_ (zip testNames results) $ \(fnName, res) -> do
-            outputLn ""
-            outputLn $ "---- " ++ show fnName ++ " counterexamples ----"
-            mapM_ printCounterexamples $ cruxSimResultGoals res
+            when (not $ isResultOK res) $ do
+                outputLn ""
+                outputLn $ "---- " ++ show fnName ++ " counterexamples ----"
+                mapM_ printCounterexamples $ cruxSimResultGoals res
 
     -- Print final tally of proved/disproved goals (except if
     -- --print-result-only is set)

--- a/test/symb_eval/any/downcast.good
+++ b/test/symb_eval/any/downcast.good
@@ -1,3 +1,4 @@
-1
+test downcast/3a1fbbbh::crux_test[0]: returned 1, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/any/downcast_fail.good
+++ b/test/symb_eval/any/downcast_fail.good
@@ -1,3 +1,11 @@
+test downcast_fail/3a1fbbbh::crux_test[0]: FAILED
+
+failures:
+
+---- downcast_fail/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for failed to downcast Any as BVRepr 32
+in downcast_fail/3a1fbbbh::crux_test[0] at test/symb_eval/any/downcast_fail.rs:11:14
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -5,5 +13,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for failed to downcast Any as BVRepr 32
-in downcast_fail/3a1fbbbh::crux_test[0] at test/symb_eval/any/downcast_fail.rs:11:14

--- a/test/symb_eval/array/basic.good
+++ b/test/symb_eval/array/basic.good
@@ -1,3 +1,4 @@
-3
+test basic/3a1fbbbh::crux_test[0]: returned 3, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/array/mux_slice.good
+++ b/test/symb_eval/array/mux_slice.good
@@ -1,4 +1,5 @@
-Symbolic BV
+test mux_slice/3a1fbbbh::crux_test[0]: returned Symbolic BV, ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/array/slice.good
+++ b/test/symb_eval/array/slice.good
@@ -1,3 +1,4 @@
-5
+test slice/3a1fbbbh::crux_test[0]: returned 5, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/array/slice_mut.good
+++ b/test/symb_eval/array/slice_mut.good
@@ -1,3 +1,4 @@
-5
+test slice_mut/3a1fbbbh::crux_test[0]: returned 5, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bitvector/arith.good
+++ b/test/symb_eval/bitvector/arith.good
@@ -1,4 +1,5 @@
-()
+test arith/3a1fbbbh::crux_test[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 9
 [Crux]   Proved: 9

--- a/test/symb_eval/bitvector/cmp.good
+++ b/test/symb_eval/bitvector/cmp.good
@@ -1,4 +1,5 @@
-()
+test cmp/3a1fbbbh::crux_test[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 2
 [Crux]   Proved: 2

--- a/test/symb_eval/bitvector/from_to.good
+++ b/test/symb_eval/bitvector/from_to.good
@@ -1,3 +1,4 @@
-()
+test from_to/3a1fbbbh::crux_test[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bitvector/leading_zeros.good
+++ b/test/symb_eval/bitvector/leading_zeros.good
@@ -1,4 +1,5 @@
-()
+test leading_zeros/3a1fbbbh::crux_test[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 2
 [Crux]   Proved: 2

--- a/test/symb_eval/bitvector/literals.good
+++ b/test/symb_eval/bitvector/literals.good
@@ -1,3 +1,4 @@
-()
+test literals/3a1fbbbh::crux_test[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bitvector/overflowing_sub.good
+++ b/test/symb_eval/bitvector/overflowing_sub.good
@@ -1,4 +1,5 @@
-()
+test overflowing_sub/3a1fbbbh::crux_test[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 2
 [Crux]   Proved: 2

--- a/test/symb_eval/bitvector/symbolic.good
+++ b/test/symb_eval/bitvector/symbolic.good
@@ -1,4 +1,5 @@
-()
+test symbolic/3a1fbbbh::crux_test[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/byteorder/read.good
+++ b/test/symb_eval/byteorder/read.good
@@ -1,3 +1,4 @@
-0
+test read/3a1fbbbh::crux_test[0]: returned 0, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/byteorder/write.good
+++ b/test/symb_eval/byteorder/write.good
@@ -1,3 +1,4 @@
-0
+test write/3a1fbbbh::crux_test[0]: returned 0, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bytes/extend_bytes.good
+++ b/test/symb_eval/bytes/extend_bytes.good
@@ -1,3 +1,4 @@
-()
+test extend_bytes/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bytes/new.good
+++ b/test/symb_eval/bytes/new.good
@@ -1,3 +1,4 @@
-()
+test new/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bytes/put.good
+++ b/test/symb_eval/bytes/put.good
@@ -1,3 +1,4 @@
-()
+test put/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bytes/put_overflow.good
+++ b/test/symb_eval/bytes/put_overflow.good
@@ -1,3 +1,11 @@
+test put_overflow/3a1fbbbh::f[0]: FAILED
+
+failures:
+
+---- put_overflow/3a1fbbbh::f[0] counterexamples ----
+Failure for panicking::begin_panic, called from bytes/3a1fbbbh::{{impl}}[4]::put_slice[0]
+in bytes/3a1fbbbh::{{impl}}[4]::put_slice[0] at <::std::macros::panic macros>:4:15: 4:70
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -5,5 +13,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for panicking::begin_panic, called from bytes/3a1fbbbh::{{impl}}[4]::put_slice[0]
-in bytes/3a1fbbbh::{{impl}}[4]::put_slice[0] at <::std::macros::panic macros>:4:15: 4:70

--- a/test/symb_eval/bytes/split_off.good
+++ b/test/symb_eval/bytes/split_off.good
@@ -1,3 +1,4 @@
-()
+test split_off/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bytes/split_to.good
+++ b/test/symb_eval/bytes/split_to.good
@@ -1,3 +1,4 @@
-()
+test split_to/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/bytes/sym_len.good
+++ b/test/symb_eval/bytes/sym_len.good
@@ -1,4 +1,5 @@
-()
+test sym_len/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 27
 [Crux]   Proved: 27

--- a/test/symb_eval/concretize/array.good
+++ b/test/symb_eval/concretize/array.good
@@ -1,3 +1,4 @@
-(1, 2, 3)
+test array/3a1fbbbh::crux_test[0]: returned (1, 2, 3), ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/assert.good
+++ b/test/symb_eval/concretize/assert.good
@@ -1,4 +1,12 @@
-1
+test assert/3a1fbbbh::crux_test[0]: returned 1, FAILED
+
+failures:
+
+---- assert/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/concretize/assert.rs:11:5:
+	100 + 157 == 1
+in assert/3a1fbbbh::crux_test[0] at <::crucible::crucible_assert macros>:12:18: 13:79
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -6,6 +14,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for MIR assertion at test/symb_eval/concretize/assert.rs:11:5:
-	100 + 157 == 1
-in assert/3a1fbbbh::crux_test[0] at <::crucible::crucible_assert macros>:12:18: 13:79

--- a/test/symb_eval/concretize/assert_ok.good
+++ b/test/symb_eval/concretize/assert_ok.good
@@ -1,4 +1,5 @@
-1
+test assert_ok/3a1fbbbh::crux_test[0]: returned 1, ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/concretize/conc.good
+++ b/test/symb_eval/concretize/conc.good
@@ -1,3 +1,4 @@
-(1, 0)
+test conc/3a1fbbbh::crux_test[0]: returned (1, 0), ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/no_conc.good
+++ b/test/symb_eval/concretize/no_conc.good
@@ -1,4 +1,5 @@
-(Symbolic BV, Symbolic BV)
+test no_conc/3a1fbbbh::crux_test[0]: returned (Symbolic BV, Symbolic BV), ok
+
 [Crux] Goal status:
 [Crux]   Total: 2
 [Crux]   Proved: 2

--- a/test/symb_eval/crux/early_fail.good
+++ b/test/symb_eval/crux/early_fail.good
@@ -1,0 +1,13 @@
+early_fail/3a1fbbbh::fail2[0]: OK
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 0
+[Crux]   Disproved: 2
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.
+[Crux] Failure for panicking::begin_panic, called from early_fail/3a1fbbbh::fail1[0]
+in early_fail/3a1fbbbh::fail1[0] at <::std::macros::panic macros>:4:15: 4:70
+[Crux] Failure for MIR assertion at test/symb_eval/crux/early_fail.rs:18:5:
+	x == 0
+in early_fail/3a1fbbbh::fail2[0] at test/symb_eval/crux/early_fail.rs:18:22

--- a/test/symb_eval/crux/early_fail.good
+++ b/test/symb_eval/crux/early_fail.good
@@ -1,4 +1,17 @@
-early_fail/3a1fbbbh::fail2[0]: OK
+test early_fail/3a1fbbbh::fail1[0]: FAILED
+test early_fail/3a1fbbbh::fail2[0]: FAILED
+
+failures:
+
+---- early_fail/3a1fbbbh::fail1[0] counterexamples ----
+Failure for panicking::begin_panic, called from early_fail/3a1fbbbh::fail1[0]
+in early_fail/3a1fbbbh::fail1[0] at <::std::macros::panic macros>:4:15: 4:70
+
+---- early_fail/3a1fbbbh::fail2[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/early_fail.rs:18:5:
+	x == 0
+in early_fail/3a1fbbbh::fail2[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
 [Crux] Goal status:
 [Crux]   Total: 2
 [Crux]   Proved: 0
@@ -6,8 +19,3 @@ early_fail/3a1fbbbh::fail2[0]: OK
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for panicking::begin_panic, called from early_fail/3a1fbbbh::fail1[0]
-in early_fail/3a1fbbbh::fail1[0] at <::std::macros::panic macros>:4:15: 4:70
-[Crux] Failure for MIR assertion at test/symb_eval/crux/early_fail.rs:18:5:
-	x == 0
-in early_fail/3a1fbbbh::fail2[0] at test/symb_eval/crux/early_fail.rs:18:22

--- a/test/symb_eval/crux/early_fail.rs
+++ b/test/symb_eval/crux/early_fail.rs
@@ -1,0 +1,19 @@
+#![feature(custom_attribute)]
+
+extern crate crucible;
+use crucible::*;
+
+// The naive implementation that simply invokes `fail1(); fail2();` will produce only one panic,
+// because `fail1` panics (terminating execution) on all branches and `fail2` never runs.  The
+// desired behavior is to run both `fail1` and `fail2` and report their errors independently.
+
+#[crux_test]
+fn fail1() {
+    panic!("bad 1");
+}
+
+#[crux_test]
+fn fail2() {
+    let x = u8::symbolic("x");
+    crucible_assert!(x == 0);
+}

--- a/test/symb_eval/crux/fail_return.good
+++ b/test/symb_eval/crux/fail_return.good
@@ -1,0 +1,22 @@
+test fail_return/3a1fbbbh::fail1[0]: returned Symbolic BV, FAILED
+test fail_return/3a1fbbbh::fail2[0]: returned 123, FAILED
+
+failures:
+
+---- fail_return/3a1fbbbh::fail1[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/fail_return.rs:9:5:
+	x + 1 > x
+in fail_return/3a1fbbbh::fail1[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
+---- fail_return/3a1fbbbh::fail2[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/fail_return.rs:16:5:
+	x + 1 > x
+in fail_return/3a1fbbbh::fail2[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 0
+[Crux]   Disproved: 2
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.

--- a/test/symb_eval/crux/fail_return.rs
+++ b/test/symb_eval/crux/fail_return.rs
@@ -1,0 +1,19 @@
+#![feature(custom_attribute)]
+
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn fail1() -> u8 {
+    let x = u8::symbolic("x");
+    crucible_assert!(x + 1 > x);
+    x
+}
+
+#[crux_test]
+fn fail2() -> u8 {
+    let x = u8::symbolic("x");
+    crucible_assert!(x + 1 > x);
+    123
+}
+

--- a/test/symb_eval/crux/mixed_fail.good
+++ b/test/symb_eval/crux/mixed_fail.good
@@ -1,0 +1,24 @@
+test mixed_fail/3a1fbbbh::fail1[0]: FAILED
+test mixed_fail/3a1fbbbh::fail2[0]: FAILED
+test mixed_fail/3a1fbbbh::pass1[0]: ok
+test mixed_fail/3a1fbbbh::pass2[0]: ok
+
+failures:
+
+---- mixed_fail/3a1fbbbh::fail1[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/mixed_fail.rs:9:5:
+	x + 1 > x
+in mixed_fail/3a1fbbbh::fail1[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
+---- mixed_fail/3a1fbbbh::fail2[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/mixed_fail.rs:15:5:
+	x + 2 > x
+in mixed_fail/3a1fbbbh::fail2[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
+[Crux] Goal status:
+[Crux]   Total: 4
+[Crux]   Proved: 2
+[Crux]   Disproved: 2
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.

--- a/test/symb_eval/crux/mixed_fail.rs
+++ b/test/symb_eval/crux/mixed_fail.rs
@@ -1,0 +1,28 @@
+#![feature(custom_attribute)]
+
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn fail1() {
+    let x = u8::symbolic("x");
+    crucible_assert!(x + 1 > x);
+}
+
+#[crux_test]
+fn fail2() {
+    let x = u8::symbolic("x");
+    crucible_assert!(x + 2 > x);
+}
+
+#[crux_test]
+fn pass1() {
+    let x = u8::symbolic("x");
+    crucible_assert!(x > 10 || x <= 10);
+}
+
+#[crux_test]
+fn pass2() {
+    let x = u8::symbolic("x");
+    crucible_assert!(x > 20 || x <= 20);
+}

--- a/test/symb_eval/crux/multi.good
+++ b/test/symb_eval/crux/multi.good
@@ -1,0 +1,18 @@
+multi/3a1fbbbh::fail3[0]: OK
+multi/3a1fbbbh::fail2[0]: OK
+multi/3a1fbbbh::fail1[0]: OK
+[Crux] Goal status:
+[Crux]   Total: 3
+[Crux]   Proved: 0
+[Crux]   Disproved: 3
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.
+[Crux] Failure for MIR assertion at test/symb_eval/crux/multi.rs:21:5:
+	x == 0
+in multi/3a1fbbbh::assert_zero[0] at test/symb_eval/crux/multi.rs:21:22
+[Crux] Failure for panicking::begin_panic, called from multi/3a1fbbbh::fail2[0]
+in multi/3a1fbbbh::fail2[0] at <::std::macros::panic macros>:4:15: 4:70
+[Crux] Failure for MIR assertion at test/symb_eval/crux/multi.rs:9:5:
+	x + 1 > x
+in multi/3a1fbbbh::fail1[0] at test/symb_eval/crux/multi.rs:9:22

--- a/test/symb_eval/crux/multi.good
+++ b/test/symb_eval/crux/multi.good
@@ -1,6 +1,23 @@
-multi/3a1fbbbh::fail3[0]: OK
-multi/3a1fbbbh::fail2[0]: OK
-multi/3a1fbbbh::fail1[0]: OK
+test multi/3a1fbbbh::fail1[0]: FAILED
+test multi/3a1fbbbh::fail2[0]: FAILED
+test multi/3a1fbbbh::fail3[0]: FAILED
+
+failures:
+
+---- multi/3a1fbbbh::fail1[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/multi.rs:9:5:
+	x + 1 > x
+in multi/3a1fbbbh::fail1[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
+---- multi/3a1fbbbh::fail2[0] counterexamples ----
+Failure for panicking::begin_panic, called from multi/3a1fbbbh::fail2[0]
+in multi/3a1fbbbh::fail2[0] at <::std::macros::panic macros>:4:15: 4:70
+
+---- multi/3a1fbbbh::fail3[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crux/multi.rs:21:5:
+	x == 0
+in multi/3a1fbbbh::assert_zero[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
 [Crux] Goal status:
 [Crux]   Total: 3
 [Crux]   Proved: 0
@@ -8,11 +25,3 @@ multi/3a1fbbbh::fail1[0]: OK
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for MIR assertion at test/symb_eval/crux/multi.rs:21:5:
-	x == 0
-in multi/3a1fbbbh::assert_zero[0] at test/symb_eval/crux/multi.rs:21:22
-[Crux] Failure for panicking::begin_panic, called from multi/3a1fbbbh::fail2[0]
-in multi/3a1fbbbh::fail2[0] at <::std::macros::panic macros>:4:15: 4:70
-[Crux] Failure for MIR assertion at test/symb_eval/crux/multi.rs:9:5:
-	x + 1 > x
-in multi/3a1fbbbh::fail1[0] at test/symb_eval/crux/multi.rs:9:22

--- a/test/symb_eval/crux/multi.rs
+++ b/test/symb_eval/crux/multi.rs
@@ -1,0 +1,28 @@
+#![feature(custom_attribute)]
+
+extern crate crucible;
+use crucible::*;
+
+#[crux_test]
+fn fail1() {
+    let x = u8::symbolic("x");
+    crucible_assert!(x + 1 > x);
+}
+
+#[crux_test]
+fn fail2() {
+    let x = u8::symbolic("x");
+    if x == 0 {
+        panic!("one")
+    }
+}
+
+fn assert_zero(x: u8) {
+    crucible_assert!(x == 0);
+}
+
+#[crux_test]
+fn fail3() {
+    let x = u8::symbolic("x");
+    assert_zero(x);
+}

--- a/test/symb_eval/crypto/bytes.good
+++ b/test/symb_eval/crypto/bytes.good
@@ -1,4 +1,24 @@
-()
+test bytes/3a1fbbbh::f[0]: FAILED
+
+failures:
+
+---- bytes/3a1fbbbh::f[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
+	a[i] == b[i]
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
+	a[i] == b[i]
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
+	a[i] == b[i]
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
+	a[i] == b[i]
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
+	a[i] == b[i]
+in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
 [Crux] Goal status:
 [Crux]   Total: 5
 [Crux]   Proved: 0
@@ -6,18 +26,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
-	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
-[Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
-	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
-[Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
-	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
-[Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
-	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
-[Crux] Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:86:7:
-	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/crypto/bytes2.good
+++ b/test/symb_eval/crypto/bytes2.good
@@ -1,4 +1,5 @@
-()
+test bytes2/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 11
 [Crux]   Proved: 11

--- a/test/symb_eval/crypto/double.good
+++ b/test/symb_eval/crypto/double.good
@@ -1,4 +1,5 @@
-()
+test double/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/crypto/ffs.good
+++ b/test/symb_eval/crypto/ffs.good
@@ -1,4 +1,5 @@
-()
+test ffs/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/enum/mux.good
+++ b/test/symb_eval/enum/mux.good
@@ -1,4 +1,5 @@
-()
+test mux/3a1fbbbh::test[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 3
 [Crux]   Proved: 3

--- a/test/symb_eval/fnptr/mux.good
+++ b/test/symb_eval/fnptr/mux.good
@@ -1,3 +1,4 @@
-2
+test mux/3a1fbbbh::crux_test[0]: returned 2, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/io/vec_cursor_read.good
+++ b/test/symb_eval/io/vec_cursor_read.good
@@ -1,3 +1,4 @@
-()
+test vec_cursor_read/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/io/vec_write.good
+++ b/test/symb_eval/io/vec_write.good
@@ -1,3 +1,4 @@
-()
+test vec_write/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/overrides/bad_symb1.good
+++ b/test/symb_eval/overrides/bad_symb1.good
@@ -1,3 +1,11 @@
+test bad_symb1/3a1fbbbh::crux_test[0]: FAILED
+
+failures:
+
+---- bad_symb1/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for symbolic variable name must be a concrete string
+in crucible/3a1fbbbh::symbolic[0]::{{impl}}[1]::symbolic[0] at lib/crucible/symbolic.rs:24:64
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -5,5 +13,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for symbolic variable name must be a concrete string
-in crucible/3a1fbbbh::symbolic[0]::{{impl}}[1]::symbolic[0] at lib/crucible/symbolic.rs:24:64

--- a/test/symb_eval/overrides/bad_symb2.good
+++ b/test/symb_eval/overrides/bad_symb2.good
@@ -1,3 +1,11 @@
+test bad_symb2/3a1fbbbh::crux_test[0]: FAILED
+
+failures:
+
+---- bad_symb2/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
+in crucible/3a1fbbbh::symbolic[0]::{{impl}}[1]::symbolic[0] at lib/crucible/symbolic.rs:24:64
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -5,5 +13,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for invalid symbolic variable name "\NUL:., /": Identifier must start with a letter.
-in crucible/3a1fbbbh::symbolic[0]::{{impl}}[1]::symbolic[0] at lib/crucible/symbolic.rs:24:64

--- a/test/symb_eval/overrides/override1.good
+++ b/test/symb_eval/overrides/override1.good
@@ -1,4 +1,5 @@
-Hello, I'm an override
-2
+test override1/3a1fbbbh::f[0]: Hello, I'm an override
+returned 2, ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/overrides/override2.good
+++ b/test/symb_eval/overrides/override2.good
@@ -1,4 +1,12 @@
-()
+test override2/3a1fbbbh::f[0]: FAILED
+
+failures:
+
+---- override2/3a1fbbbh::f[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/overrides/override2.rs:10:5:
+	foo + 1 == foo
+in override2/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -6,6 +14,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for MIR assertion at test/symb_eval/overrides/override2.rs:10:5:
-	foo + 1 == foo
-in override2/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/overrides/override3.good
+++ b/test/symb_eval/overrides/override3.good
@@ -1,4 +1,5 @@
-()
+test override3/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/overrides/override4.good
+++ b/test/symb_eval/overrides/override4.good
@@ -1,4 +1,5 @@
-()
+test override4/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/overrides/override5.good
+++ b/test/symb_eval/overrides/override5.good
@@ -1,4 +1,12 @@
-()
+test override5/3a1fbbbh::f[0]: FAILED
+
+failures:
+
+---- override5/3a1fbbbh::f[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/overrides/override5.rs:11:5:
+	foo + 1 != 0
+in override5/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -6,6 +14,3 @@
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for MIR assertion at test/symb_eval/overrides/override5.rs:11:5:
-	foo + 1 != 0
-in override5/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/scalar/test1.good
+++ b/test/symb_eval/scalar/test1.good
@@ -1,4 +1,5 @@
-()
+test test1/3a1fbbbh::f[0]: ok
+
 [Crux] Goal status:
 [Crux]   Total: 77
 [Crux]   Proved: 77

--- a/test/symb_eval/sym_bytes/construct.good
+++ b/test/symb_eval/sym_bytes/construct.good
@@ -1,4 +1,12 @@
-Symbolic BV
+test construct/3a1fbbbh::crux_test[0]: returned Symbolic BV, FAILED
+
+failures:
+
+---- construct/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for MIR assertion at test/symb_eval/sym_bytes/construct.rs:14:5:
+	sym2[0] == 0
+in construct/3a1fbbbh::crux_test[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 0
@@ -6,6 +14,3 @@ Symbolic BV
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
 [Crux] Overall status: Invalid.
-[Crux] Failure for MIR assertion at test/symb_eval/sym_bytes/construct.rs:14:5:
-	sym2[0] == 0
-in construct/3a1fbbbh::crux_test[0] at <::crucible::crucible_assert macros>:2:42: 2:62

--- a/test/symb_eval/sym_bytes/deserialize.good
+++ b/test/symb_eval/sym_bytes/deserialize.good
@@ -1,4 +1,5 @@
-Symbolic BV
+test deserialize/3a1fbbbh::crux_test[0]: returned Symbolic BV, ok
+
 [Crux] Goal status:
 [Crux]   Total: 1
 [Crux]   Proved: 1

--- a/test/symb_eval/vec/clone.good
+++ b/test/symb_eval/vec/clone.good
@@ -1,3 +1,4 @@
-()
+test clone/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vec/into_iter.good
+++ b/test/symb_eval/vec/into_iter.good
@@ -1,3 +1,4 @@
-()
+test into_iter/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vec/macro.good
+++ b/test/symb_eval/vec/macro.good
@@ -1,3 +1,4 @@
-()
+test macro/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vec/sort_by_key.good
+++ b/test/symb_eval/vec/sort_by_key.good
@@ -1,3 +1,4 @@
-()
+test sort_by_key/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/as_mut_slice.good
+++ b/test/symb_eval/vector/as_mut_slice.good
@@ -1,3 +1,4 @@
-()
+test as_mut_slice/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/as_slice.good
+++ b/test/symb_eval/vector/as_slice.good
@@ -1,3 +1,4 @@
-()
+test as_slice/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/concat.good
+++ b/test/symb_eval/vector/concat.good
@@ -1,3 +1,4 @@
-()
+test concat/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/copy_from_slice.good
+++ b/test/symb_eval/vector/copy_from_slice.good
@@ -1,3 +1,4 @@
-()
+test copy_from_slice/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/mut.good
+++ b/test/symb_eval/vector/mut.good
@@ -1,3 +1,4 @@
-()
+test mut/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/new.good
+++ b/test/symb_eval/vector/new.good
@@ -1,3 +1,4 @@
-()
+test new/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/pop.good
+++ b/test/symb_eval/vector/pop.good
@@ -1,3 +1,4 @@
-()
+test pop/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/push.good
+++ b/test/symb_eval/vector/push.good
@@ -1,3 +1,4 @@
-()
+test push/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/replicate.good
+++ b/test/symb_eval/vector/replicate.good
@@ -1,3 +1,4 @@
-()
+test replicate/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.

--- a/test/symb_eval/vector/split_at.good
+++ b/test/symb_eval/vector/split_at.good
@@ -1,3 +1,4 @@
-()
+test split_at/3a1fbbbh::f[0]: ok
+
 [Crux] All goals discharged through internal simplification.
 [Crux] Overall status: Valid.


### PR DESCRIPTION
 * `crux-mir` now runs each test case separately.  This fixes a previous issue where a test that assumes `false` would cause later tests to be skipped.
 * The output format has changed to break down counterexample reports by test and to look more like ordinary `cargo test` output, so it should be more useful and more familiar to developers.
 * `crux-mir` now accepts a test filter: `cargo crux-test foo` will run only those tests that have `foo` in the name.  For direct invocation of `crux-mir` (not through `cargo crux-test`), the test filter can be set by passing `--test-filter foo`.

There is a matching branch GaloisInc/mir-json#15, updating `cargo-crux-test` to use the new mechanisms to provide the test filter and input filename.