### PR TITLE
Checked arithmetic

### DIFF
--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -296,172 +296,140 @@ transBinOp bop op1 op2 = do
     me1 <- evalOperand  op1
     me2 <- evalOperand  op2
     let mat = M.arithType op1 `mplus` M.arithType op2 
-    evalBinOp bop mat me1 me2
+    fst <$> evalBinOp bop mat me1 me2
 
-evalBinOp :: M.BinOp -> Maybe M.ArithType -> MirExp s -> MirExp s -> MirGenerator h s ret (MirExp s)
-evalBinOp bop mat me1 me2 = 
+-- Evaluate a binop, returning both the result and an overflow flag.
+evalBinOp :: M.BinOp -> Maybe M.ArithType -> MirExp s -> MirExp s ->
+    MirGenerator h s ret (MirExp s, R.Expr MIR s C.BoolType)
+evalBinOp bop mat me1 me2 =
     case (me1, me2) of
       (MirExp ty1@(C.BVRepr na) e1a, MirExp ty2@C.NatRepr e2a) ->
          case (bop, mat) of
             (M.Shl, _) -> do
                 let e2bv = S.app (E.IntegerToBV na (S.app (E.NatToInteger e2a)))
-                return $ MirExp (C.BVRepr na) (S.app $ E.BVShl na e1a e2bv)
+                return (MirExp (C.BVRepr na) (S.app $ E.BVShl na e1a e2bv),
+                    shiftOverflowNat na e2a)
             (M.Shr, Just M.Unsigned) -> do
                 let e2bv = S.app (E.IntegerToBV na (S.app (E.NatToInteger e2a)))
-                return $ MirExp (C.BVRepr na) (S.app $ E.BVLshr na e1a e2bv)
+                return (MirExp (C.BVRepr na) (S.app $ E.BVLshr na e1a e2bv),
+                    shiftOverflowNat na e2a)
             (M.Shr, Just M.Signed) -> do
                 let e2bv = S.app (E.IntegerToBV na (S.app (E.NatToInteger e2a)))
-                return $ MirExp (C.BVRepr na) (S.app $ E.BVAshr na e1a e2bv)
+                return (MirExp (C.BVRepr na) (S.app $ E.BVAshr na e1a e2bv),
+                    shiftOverflowNat na e2a)
 
             _ -> mirFail $ "No translation for binop: " ++ show bop ++ " with " ++ show ty1 ++ " and " ++ show ty2
-      {-
-      (MirExp C.IntegerRepr e1, MirExp C.IntegerRepr e2) ->
-            case bop of
-              M.Add -> return $ MirExp C.IntegerRepr (S.app $ E.IntAdd e1 e2)
-              M.Sub -> return $ MirExp C.IntegerRepr (S.app $ E.IntSub e1 e2)
-              M.Mul -> return $ MirExp C.IntegerRepr (S.app $ E.IntMul e1 e2)
-              M.Div -> return $ MirExp C.IntegerRepr (S.app $ E.IntDiv e1 e2)
-              M.Rem -> return $ MirExp C.IntegerRepr (S.app $ E.IntMod e1 e2)
-              M.Lt  -> return $ MirExp (C.BoolRepr) (S.app $ E.IntLt e1 e2)
-              M.Le  -> return $ MirExp (C.BoolRepr) (S.app $ E.IntLe e1 e2)
-              M.Gt  -> return $ MirExp (C.BoolRepr) (S.app $ E.IntLt e2 e1)
-              M.Ge  -> return $ MirExp (C.BoolRepr) (S.app $ E.IntLe e2 e1)
-              M.Ne  -> return $ MirExp (C.BoolRepr) (S.app $ E.Not $ S.app $ E.IntEq e1 e2)
-              M.Beq -> return $ MirExp (C.BoolRepr) (S.app $ E.IntEq e1 e2)
-
-              -- TODO: these three are rather fishy
-              M.BitXor -> do
-                let w  = (knownRepr :: NatRepr 128)
-                let b1 = S.app $ E.IntegerToBV w e1 
-                let b2 = S.app $ E.IntegerToBV w e2
-                return $ MirExp C.IntegerRepr (S.app $ E.SbvToInteger w $ S.app $ E.BVXor w b1 b2)
-              M.BitAnd -> do
-                let w  = (knownRepr :: NatRepr 128)
-                let b1 = S.app $ E.IntegerToBV w e1
-                let b2 = S.app $ E.IntegerToBV w e2
-                return $ MirExp C.IntegerRepr (S.app $ E.SbvToInteger w $ S.app $ E.BVAnd w b1 b2)
-
-              M.BitOr  -> do
-                let w  = (knownRepr :: NatRepr 128)
-                let b1 = S.app $ E.IntegerToBV w e1
-                let b2 = S.app $ E.IntegerToBV w e2
-                return $ MirExp C.IntegerRepr (S.app $ E.SbvToInteger w $ S.app $ E.BVOr w b1 b2)
-
-
-              _ -> mirFail $ "No translation for integer binop: " ++ fmt bop 
-              -}
       (MirExp ty1@(C.BVRepr na) e1a, MirExp ty2@(C.BVRepr ma) e2a) ->
           -- if the BVs are not the same width extend the shorter one
           extendToMax na e1a ma e2a (mat) $ \ n e1 e2 -> 
             case (bop, mat) of
-              (M.Add, _) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVAdd n e1 e2)
-              (M.Sub, _) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVSub n e1 e2)
-              (M.Mul, _) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVMul n e1 e2)
-              (M.Div, Just M.Unsigned) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVUdiv n e1 e2)
-              (M.Div, Just M.Signed) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVSdiv n e1 e2)
-              (M.Rem, Just M.Unsigned) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVUrem n e1 e2)
-              (M.Rem, Just M.Signed) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVSrem n e1 e2)
-              (M.BitXor, _) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVXor n e1 e2)
-              (M.BitAnd, _) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVAnd n e1 e2)
-              (M.BitOr, _) -> return $ MirExp (C.BVRepr n) (S.app $ E.BVOr n e1 e2)
-              (M.Shl, _) ->
-                 let res = MirExp (C.BVRepr n) (S.app $ E.BVShl n e1 e2)
-                 -- TODO check unsigned vs signed???
-                 in extendUnsignedBV res na
-              (M.Shr, Just M.Unsigned) ->
-                 let res = MirExp (C.BVRepr n) (S.app $ E.BVLshr n e1 e2)
-                 in extendUnsignedBV res na
-              (M.Shr, Nothing) ->
-                 let res = MirExp (C.BVRepr n) (S.app $ E.BVLshr n e1 e2)
-                 in extendUnsignedBV res na
-              (M.Shr, Just M.Signed) ->
-                 let res = MirExp (C.BVRepr n) (S.app $ E.BVAshr n e1 e2) 
-                 in extendSignedBV res na
-              (M.Lt, Just M.Unsigned) -> return $ MirExp (C.BoolRepr) (S.app $ E.BVUlt n e1 e2)
-              (M.Lt, Just M.Signed)   -> return $ MirExp (C.BoolRepr) (S.app $ E.BVSlt n e1 e2)
-              (M.Le, Just M.Unsigned) -> return $ MirExp (C.BoolRepr) (S.app $ E.BVUle n e1 e2)
-              (M.Le, Just M.Signed)   -> return $ MirExp (C.BoolRepr) (S.app $ E.BVSle n e1 e2)
+              (M.Add, _) -> do
+                let carry = case mat of
+                        Just M.Unsigned -> E.BVCarry
+                        Nothing -> E.BVCarry
+                        Just M.Signed -> E.BVSCarry
+                return (MirExp (C.BVRepr n) (S.app $ E.BVAdd n e1 e2), S.app $ carry n e1 e2)
+              (M.Sub, _) -> do
+                let borrow = case mat of
+                        Just M.Unsigned -> E.BVUlt
+                        Nothing -> E.BVUlt
+                        Just M.Signed -> E.BVSBorrow
+                return (MirExp (C.BVRepr n) (S.app $ E.BVSub n e1 e2), S.app $ borrow n e1 e2)
+              -- FIXME: implement overflow checks for Mul, Div, and Rem
+              (M.Mul, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVMul n e1 e2), unknownOverflow)
+              (M.Div, Just M.Unsigned) -> return (MirExp (C.BVRepr n) (S.app $ E.BVUdiv n e1 e2), unknownOverflow)
+              (M.Div, Just M.Signed) -> return (MirExp (C.BVRepr n) (S.app $ E.BVSdiv n e1 e2), unknownOverflow)
+              (M.Rem, Just M.Unsigned) -> return (MirExp (C.BVRepr n) (S.app $ E.BVUrem n e1 e2), unknownOverflow)
+              (M.Rem, Just M.Signed) -> return (MirExp (C.BVRepr n) (S.app $ E.BVSrem n e1 e2), unknownOverflow)
+              -- Bitwise ops never overflow
+              (M.BitXor, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVXor n e1 e2), noOverflow)
+              (M.BitAnd, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVAnd n e1 e2), noOverflow)
+              (M.BitOr, _) -> return (MirExp (C.BVRepr n) (S.app $ E.BVOr n e1 e2), noOverflow)
+              -- Shift ops overflow when shift amount >= bit width
+              -- FIXME: check the logic here.  Not sure about these truncations
+              (M.Shl, _) -> do
+                 res <- extendUnsignedBV (MirExp (C.BVRepr n) (S.app $ E.BVShl n e1 e2)) na
+                 return (res, shiftOverflowBV na ma e2a)
+              (M.Shr, Just M.Unsigned) -> do
+                 res <- extendUnsignedBV (MirExp (C.BVRepr n) (S.app $ E.BVLshr n e1 e2)) na
+                 return (res, shiftOverflowBV na ma e2a)
+              (M.Shr, Nothing) -> do
+                 res <- extendUnsignedBV (MirExp (C.BVRepr n) (S.app $ E.BVLshr n e1 e2)) na
+                 return (res, shiftOverflowBV na ma e2a)
+              (M.Shr, Just M.Signed) -> do
+                 res <- extendSignedBV (MirExp (C.BVRepr n) (S.app $ E.BVAshr n e1 e2) ) na
+                 return (res, shiftOverflowBV na ma e2a)
+              -- Comparison ops never overflow
+              (M.Lt, Just M.Unsigned) -> return (MirExp (C.BoolRepr) (S.app $ E.BVUlt n e1 e2), noOverflow)
+              (M.Lt, Just M.Signed)   -> return (MirExp (C.BoolRepr) (S.app $ E.BVSlt n e1 e2), noOverflow)
+              (M.Le, Just M.Unsigned) -> return (MirExp (C.BoolRepr) (S.app $ E.BVUle n e1 e2), noOverflow)
+              (M.Le, Just M.Signed)   -> return (MirExp (C.BoolRepr) (S.app $ E.BVSle n e1 e2), noOverflow)
 
-              (M.Gt, Just M.Unsigned) -> return $ MirExp (C.BoolRepr) (S.app $ E.BVUlt n e2 e1)
-              (M.Gt, Just M.Signed)   -> return $ MirExp (C.BoolRepr) (S.app $ E.BVSlt n e2 e1)
-              (M.Ge, Just M.Unsigned) -> return $ MirExp (C.BoolRepr) (S.app $ E.BVUle n e2 e1)
-              (M.Ge, Just M.Signed)   -> return $ MirExp (C.BoolRepr) (S.app $ E.BVSle n e2 e1)
+              (M.Gt, Just M.Unsigned) -> return (MirExp (C.BoolRepr) (S.app $ E.BVUlt n e2 e1), noOverflow)
+              (M.Gt, Just M.Signed)   -> return (MirExp (C.BoolRepr) (S.app $ E.BVSlt n e2 e1), noOverflow)
+              (M.Ge, Just M.Unsigned) -> return (MirExp (C.BoolRepr) (S.app $ E.BVUle n e2 e1), noOverflow)
+              (M.Ge, Just M.Signed)   -> return (MirExp (C.BoolRepr) (S.app $ E.BVSle n e2 e1), noOverflow)
 
-              (M.Ne, _) -> return $ MirExp (C.BoolRepr) (S.app $ E.Not $ S.app $ E.BVEq n e1 e2)
-              (M.Beq, _) -> return $ MirExp (C.BoolRepr) (S.app $ E.BVEq n e1 e2)
+              (M.Ne, _) -> return (MirExp (C.BoolRepr) (S.app $ E.Not $ S.app $ E.BVEq n e1 e2), noOverflow)
+              (M.Beq, _) -> return (MirExp (C.BoolRepr) (S.app $ E.BVEq n e1 e2), noOverflow)
               _ -> mirFail $ "No translation for binop: " ++ show bop ++ " " ++ show mat
                            ++ " for " ++ show ty1 ++ " and " ++ show ty2
       (MirExp C.BoolRepr e1, MirExp C.BoolRepr e2) ->
           case bop of
-            M.BitAnd -> return $ MirExp C.BoolRepr (S.app $ E.And e1 e2)
-            M.BitXor -> return $ MirExp C.BoolRepr (S.app $ E.BoolXor e1 e2)
-            M.BitOr -> return $ MirExp C.BoolRepr (S.app $ E.Or e1 e2)
-            M.Beq -> return $ MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.BoolXor e1 e2)
-            M.Ne  -> return $ MirExp C.BoolRepr (S.app $ E.BoolXor e1 e2)
+            M.BitAnd -> return (MirExp C.BoolRepr (S.app $ E.And e1 e2), noOverflow)
+            M.BitXor -> return (MirExp C.BoolRepr (S.app $ E.BoolXor e1 e2), noOverflow)
+            M.BitOr -> return (MirExp C.BoolRepr (S.app $ E.Or e1 e2), noOverflow)
+            M.Beq -> return (MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.BoolXor e1 e2), noOverflow)
+            M.Ne  -> return (MirExp C.BoolRepr (S.app $ E.BoolXor e1 e2), noOverflow)
             _ -> mirFail $ "No translation for bool binop: " ++ fmt bop
-    {-
-      (MirExp C.NatRepr e1, MirExp C.NatRepr e2) ->
-          case bop of
-            M.Beq -> return $ MirExp C.BoolRepr (S.app $ E.NatEq e1 e2)
-            M.Lt -> return $ MirExp C.BoolRepr (S.app $ E.NatLt e1 e2)
-            M.Le -> return $ MirExp C.BoolRepr (S.app $ E.NatLe e1 e2)
-            M.Gt -> return $ MirExp C.BoolRepr (S.app $ E.NatLt e2 e1)
-            M.Ge -> return $ MirExp C.BoolRepr (S.app $ E.NatLe e2 e1)
-
-            M.Add -> return $ MirExp C.NatRepr (S.app $ E.NatAdd e1 e2)
-            M.Sub -> return $ MirExp C.NatRepr (S.app $ E.NatSub e1 e2)
-            M.Mul -> return $ MirExp C.NatRepr (S.app $ E.NatMul e1 e2)
-            M.Div -> return $ MirExp C.NatRepr (S.app $ E.NatDiv e1 e2)
-            M.Rem -> return $ MirExp C.NatRepr (S.app $ E.NatMod e1 e2)
-            M.Ne -> return $ MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.NatEq e1 e2)
-
-            -- these three are rather fishy
-            M.BitXor -> do
-              let w  = (knownRepr :: NatRepr 128)
-              let b1 = S.app $ E.IntegerToBV w (S.app $ E.NatToInteger e1)
-              let b2 = S.app $ E.IntegerToBV w (S.app $ E.NatToInteger e1)
-              return $ MirExp C.NatRepr (S.app $ E.BvToNat w $ S.app $ E.BVXor w b1 b2)
-            M.BitAnd -> do
-              let w  = (knownRepr :: NatRepr 128)
-              let b1 = S.app $ E.IntegerToBV w (S.app $ E.NatToInteger e1)
-              let b2 = S.app $ E.IntegerToBV w (S.app $ E.NatToInteger e1)
-              return $ MirExp C.NatRepr (S.app $ E.BvToNat w $ S.app $ E.BVAnd w b1 b2)
-
-            M.BitOr  -> do
-              let w  = (knownRepr :: NatRepr 128)
-              let b1 = S.app $ E.IntegerToBV w (S.app $ E.NatToInteger e1)
-              let b2 = S.app $ E.IntegerToBV w (S.app $ E.NatToInteger e1)
-              return $ MirExp C.NatRepr (S.app $ E.BvToNat w $ S.app $ E.BVOr w b1 b2)
-
-
-            _ -> mirFail $ "No translation for natural number binop: " ++ fmt bop
-      -}
       (MirExp C.RealValRepr e1, MirExp C.RealValRepr e2) ->
           case bop of
-            M.Beq -> return $ MirExp C.BoolRepr (S.app $ E.RealEq e1 e2)
-            M.Lt -> return $ MirExp C.BoolRepr (S.app $ E.RealLt e1 e2)
-            M.Le -> return $ MirExp C.BoolRepr (S.app $ E.RealLe e1 e2)
-            M.Gt -> return $ MirExp C.BoolRepr (S.app $ E.RealLt e2 e1)
-            M.Ge -> return $ MirExp C.BoolRepr (S.app $ E.RealLe e2 e1)
+            M.Beq -> return (MirExp C.BoolRepr (S.app $ E.RealEq e1 e2), noOverflow)
+            M.Lt -> return (MirExp C.BoolRepr (S.app $ E.RealLt e1 e2), noOverflow)
+            M.Le -> return (MirExp C.BoolRepr (S.app $ E.RealLe e1 e2), noOverflow)
+            M.Gt -> return (MirExp C.BoolRepr (S.app $ E.RealLt e2 e1), noOverflow)
+            M.Ge -> return (MirExp C.BoolRepr (S.app $ E.RealLe e2 e1), noOverflow)
+            M.Ne -> return (MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.RealEq e1 e2), noOverflow)
 
-            M.Add -> return $ MirExp C.RealValRepr (S.app $ E.RealAdd e1 e2)
-            M.Sub -> return $ MirExp C.RealValRepr (S.app $ E.RealSub e1 e2)
-            M.Mul -> return $ MirExp C.RealValRepr (S.app $ E.RealMul e1 e2)
-            M.Div -> return $ MirExp C.RealValRepr (S.app $ E.RealDiv e1 e2)
-            M.Rem -> return $ MirExp C.RealValRepr (S.app $ E.RealMod e1 e2)
-            M.Ne -> return $ MirExp C.BoolRepr (S.app $ E.Not $ S.app $ E.RealEq e1 e2)
+            -- Binops on floats never set the overflow flag
+            M.Add -> return (MirExp C.RealValRepr (S.app $ E.RealAdd e1 e2), noOverflow)
+            M.Sub -> return (MirExp C.RealValRepr (S.app $ E.RealSub e1 e2), noOverflow)
+            M.Mul -> return (MirExp C.RealValRepr (S.app $ E.RealMul e1 e2), noOverflow)
+            M.Div -> return (MirExp C.RealValRepr (S.app $ E.RealDiv e1 e2), noOverflow)
+            M.Rem -> return (MirExp C.RealValRepr (S.app $ E.RealMod e1 e2), noOverflow)
 
             _ -> mirFail $ "No translation for real number binop: " ++ fmt bop
 
       (_, _) -> mirFail $ "bad or unimplemented type: " ++ (fmt bop) ++ ", " ++ (show me1) ++ ", " ++ (show me2)
 
+  where
+    noOverflow :: R.Expr MIR s C.BoolType
+    noOverflow = S.app $ E.BoolLit False
+    -- For now, assume unsupported operations don't overflow.  Eventually all
+    -- overflow checks should be implemented, and we can remove this.
+    unknownOverflow = noOverflow
+
+    -- Check that shift amount `e` is less than the input width `w`.
+    shiftOverflowNat w e =
+        let wLit = S.app $ E.NatLit $ natValue w
+        in S.app $ E.Not $ S.app $ E.NatLt e wLit
+    -- Check that shift amount `e` (whose width in `w'`) is less than the input
+    -- width `w`.
+    shiftOverflowBV :: (1 <= w') =>
+        NatRepr w -> NatRepr w' -> R.Expr MIR s (C.BVType w') -> R.Expr MIR s C.BoolType
+    shiftOverflowBV w w' e =
+        let wLit = S.app $ E.BVLit w' $ intValue w
+        in S.app $ E.Not $ S.app $ E.BVUlt w' e wLit
+
 
 
 transCheckedBinOp ::  M.BinOp -> M.Operand -> M.Operand -> MirGenerator h s ret (MirExp s) -- returns tuple of (result, bool)
-transCheckedBinOp  a b c = do
-    res <- transBinOp a b c
-    return $ buildTupleMaybe [error "not needed", TyBool] [Just res, Just $ MirExp (C.BoolRepr) (S.litExpr False)]
-         -- This always succeeds, since we're checking correctness. We can also check for overflow if desired.
+transCheckedBinOp op a b = do
+    a' <- evalOperand  a
+    b' <- evalOperand  b
+    let mat = M.arithType a `mplus` M.arithType b
+    (res, overflow) <- evalBinOp op mat a' b'
+    return $ buildTupleMaybe [error "not needed", TyBool] [Just res, Just $ MirExp (C.BoolRepr) overflow]
 
 
 -- Nullary ops in rust are used for resource allocation, so are not interpreted

--- a/test/symb_eval/bitvector/arith.good
+++ b/test/symb_eval/bitvector/arith.good
@@ -1,8 +1,8 @@
 test arith/3a1fbbbh::crux_test[0]: ok
 
 [Crux] Goal status:
-[Crux]   Total: 9
-[Crux]   Proved: 9
+[Crux]   Total: 11
+[Crux]   Proved: 11
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/bitvector/symbolic.rs
+++ b/test/symb_eval/bitvector/symbolic.rs
@@ -14,6 +14,7 @@ fn crux_test() {
     {
         let a = Bv256::symbolic("a");
         let b = Bv256::symbolic("b");
-        crucible_assert!((u64::from(a) + u64::from(b)) == u64::from(a + b));
+        // Bv256 addition is always wrapping.
+        crucible_assert!((u64::from(a).wrapping_add(u64::from(b))) == u64::from(a + b));
     }
 }

--- a/test/symb_eval/bytes/sym_len.good
+++ b/test/symb_eval/bytes/sym_len.good
@@ -1,8 +1,8 @@
 test sym_len/3a1fbbbh::f[0]: ok
 
 [Crux] Goal status:
-[Crux]   Total: 27
-[Crux]   Proved: 27
+[Crux]   Total: 40
+[Crux]   Proved: 40
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/concretize/array.good
+++ b/test/symb_eval/concretize/array.good
@@ -1,4 +1,9 @@
 test array/3a1fbbbh::crux_test[0]: returned (1, 2, 3), ok
 
-[Crux] All goals discharged through internal simplification.
+[Crux] Goal status:
+[Crux]   Total: 2
+[Crux]   Proved: 2
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/assert.rs
+++ b/test/symb_eval/concretize/assert.rs
@@ -6,10 +6,10 @@ use crucible::*;
 fn crux_test() -> u8 {
     let mut x = u8::symbolic("x");
     let mut y = u8::symbolic("y");
-    crucible_assume!(x + y == 1);
+    crucible_assume!(x.wrapping_add(y) == 1);
     if x > 1 { crucible_assume!(x == 100) }
-    crucible_assert!(x == 0 || x == 1, "{} + {} == {}", x, y, x + y);
-    concretize(x + y)
+    crucible_assert!(x == 0 || x == 1, "{} + {} == {}", x, y, x.wrapping_add(y));
+    concretize(x.wrapping_add(y))
 }
 
 pub fn main() {

--- a/test/symb_eval/concretize/assert_ok.good
+++ b/test/symb_eval/concretize/assert_ok.good
@@ -1,8 +1,8 @@
 test assert_ok/3a1fbbbh::crux_test[0]: returned 1, ok
 
 [Crux] Goal status:
-[Crux]   Total: 1
-[Crux]   Proved: 1
+[Crux]   Total: 4
+[Crux]   Proved: 4
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/concretize/assert_ok.rs
+++ b/test/symb_eval/concretize/assert_ok.rs
@@ -6,8 +6,8 @@ use crucible::*;
 fn crux_test() -> u8 {
     let mut x = u8::symbolic("x");
     let mut y = u8::symbolic("y");
-    crucible_assume!(x + y == 1);
     crucible_assume!(x < 100 && y < 100);
+    crucible_assume!(x + y == 1);
     crucible_assert!(x == 0 || x == 1, "{} + {} == {}", x, y, x + y);
     concretize(x + y)
 }

--- a/test/symb_eval/concretize/conc.good
+++ b/test/symb_eval/concretize/conc.good
@@ -1,4 +1,9 @@
 test conc/3a1fbbbh::crux_test[0]: returned (1, 0), ok
 
-[Crux] All goals discharged through internal simplification.
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 1
+[Crux]   Disproved: 0
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
 [Crux] Overall status: Valid.

--- a/test/symb_eval/concretize/no_conc.good
+++ b/test/symb_eval/concretize/no_conc.good
@@ -1,8 +1,8 @@
 test no_conc/3a1fbbbh::crux_test[0]: returned (Symbolic BV, Symbolic BV), ok
 
 [Crux] Goal status:
-[Crux]   Total: 2
-[Crux]   Proved: 2
+[Crux]   Total: 3
+[Crux]   Proved: 3
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/crux/fail_return.good
+++ b/test/symb_eval/crux/fail_return.good
@@ -4,18 +4,16 @@ test fail_return/3a1fbbbh::fail2[0]: returned 123, FAILED
 failures:
 
 ---- fail_return/3a1fbbbh::fail1[0] counterexamples ----
-Failure for MIR assertion at test/symb_eval/crux/fail_return.rs:9:5:
-	x + 1 > x
-in fail_return/3a1fbbbh::fail1[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for attempt to add with overflow
+in fail_return/3a1fbbbh::fail1[0] at test/symb_eval/crux/fail_return.rs:9:22
 
 ---- fail_return/3a1fbbbh::fail2[0] counterexamples ----
-Failure for MIR assertion at test/symb_eval/crux/fail_return.rs:16:5:
-	x + 1 > x
-in fail_return/3a1fbbbh::fail2[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for attempt to add with overflow
+in fail_return/3a1fbbbh::fail2[0] at test/symb_eval/crux/fail_return.rs:16:22
 
 [Crux] Goal status:
-[Crux]   Total: 2
-[Crux]   Proved: 0
+[Crux]   Total: 4
+[Crux]   Proved: 2
 [Crux]   Disproved: 2
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/crux/mixed_fail.good
+++ b/test/symb_eval/crux/mixed_fail.good
@@ -6,18 +6,16 @@ test mixed_fail/3a1fbbbh::pass2[0]: ok
 failures:
 
 ---- mixed_fail/3a1fbbbh::fail1[0] counterexamples ----
-Failure for MIR assertion at test/symb_eval/crux/mixed_fail.rs:9:5:
-	x + 1 > x
-in mixed_fail/3a1fbbbh::fail1[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for attempt to add with overflow
+in mixed_fail/3a1fbbbh::fail1[0] at test/symb_eval/crux/mixed_fail.rs:9:22
 
 ---- mixed_fail/3a1fbbbh::fail2[0] counterexamples ----
-Failure for MIR assertion at test/symb_eval/crux/mixed_fail.rs:15:5:
-	x + 2 > x
-in mixed_fail/3a1fbbbh::fail2[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for attempt to add with overflow
+in mixed_fail/3a1fbbbh::fail2[0] at test/symb_eval/crux/mixed_fail.rs:15:22
 
 [Crux] Goal status:
-[Crux]   Total: 4
-[Crux]   Proved: 2
+[Crux]   Total: 6
+[Crux]   Proved: 4
 [Crux]   Disproved: 2
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/crux/multi.good
+++ b/test/symb_eval/crux/multi.good
@@ -5,9 +5,8 @@ test multi/3a1fbbbh::fail3[0]: FAILED
 failures:
 
 ---- multi/3a1fbbbh::fail1[0] counterexamples ----
-Failure for MIR assertion at test/symb_eval/crux/multi.rs:9:5:
-	x + 1 > x
-in multi/3a1fbbbh::fail1[0] at <::crucible::crucible_assert macros>:2:42: 2:62
+Failure for attempt to add with overflow
+in multi/3a1fbbbh::fail1[0] at test/symb_eval/crux/multi.rs:9:22
 
 ---- multi/3a1fbbbh::fail2[0] counterexamples ----
 Failure for panicking::begin_panic, called from multi/3a1fbbbh::fail2[0]
@@ -19,8 +18,8 @@ Failure for MIR assertion at test/symb_eval/crux/multi.rs:21:5:
 in multi/3a1fbbbh::assert_zero[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 
 [Crux] Goal status:
-[Crux]   Total: 3
-[Crux]   Proved: 0
+[Crux]   Total: 4
+[Crux]   Proved: 1
 [Crux]   Disproved: 3
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/crypto/ffs.good
+++ b/test/symb_eval/crypto/ffs.good
@@ -1,8 +1,8 @@
 test ffs/3a1fbbbh::f[0]: ok
 
 [Crux] Goal status:
-[Crux]   Total: 1
-[Crux]   Proved: 1
+[Crux]   Total: 5
+[Crux]   Proved: 5
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/crypto/ffs.rs
+++ b/test/symb_eval/crypto/ffs.rs
@@ -25,7 +25,7 @@ fn ffs_imp(j : u32) -> u32 {
     if (i & 0x000f) == 0 { n +=  4; i >>=  4; }
     if (i & 0x0003) == 0 { n +=  2; i >>=  2; }
     let nn = n as u32;
-    if i != 0 { return nn+((i+1) & 0x01); } else { return 0; }
+    if i != 0 { return nn+((i.wrapping_add(1)) & 0x01); } else { return 0; }
 }
 
 

--- a/test/symb_eval/num/checked_add.good
+++ b/test/symb_eval/num/checked_add.good
@@ -1,0 +1,15 @@
+test checked_add/3a1fbbbh::crux_test[0]: FAILED
+
+failures:
+
+---- checked_add/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for attempt to add with overflow
+in checked_add/3a1fbbbh::crux_test[0] at test/symb_eval/num/checked_add.rs:6:5
+
+[Crux] Goal status:
+[Crux]   Total: 1
+[Crux]   Proved: 0
+[Crux]   Disproved: 1
+[Crux]   Incomplete: 0
+[Crux]   Unknown: 0
+[Crux] Overall status: Invalid.

--- a/test/symb_eval/num/checked_add.rs
+++ b/test/symb_eval/num/checked_add.rs
@@ -1,0 +1,11 @@
+#![feature(custom_attribute)]
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let x = 200;
+    100 + x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/num/checked_mul.good
+++ b/test/symb_eval/num/checked_mul.good
@@ -1,0 +1,4 @@
+test checked_mul/3a1fbbbh::crux_test[0]: returned 44, ok
+
+[Crux] All goals discharged through internal simplification.
+[Crux] Overall status: Valid.

--- a/test/symb_eval/num/checked_mul.rs
+++ b/test/symb_eval/num/checked_mul.rs
@@ -1,0 +1,12 @@
+#![feature(custom_attribute)]
+// FIXME: currently passes, but should fail
+
+#[crux_test]
+fn crux_test() -> u8 {
+    let x = 3;
+    100 * x
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/overrides/override2.good
+++ b/test/symb_eval/overrides/override2.good
@@ -4,7 +4,7 @@ failures:
 
 ---- override2/3a1fbbbh::f[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/overrides/override2.rs:10:5:
-	foo + 1 == foo
+	foo.wrapping_add(1) == foo
 in override2/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 
 [Crux] Goal status:

--- a/test/symb_eval/overrides/override2.rs
+++ b/test/symb_eval/overrides/override2.rs
@@ -7,5 +7,5 @@ use crucible::*;
 pub fn f() {
     // This call should be replaced by the test override
     let foo = crucible_i8("foo");
-    crucible_assert!(foo + 1 == foo);
+    crucible_assert!(foo.wrapping_add(1) == foo);
 }

--- a/test/symb_eval/overrides/override3.rs
+++ b/test/symb_eval/overrides/override3.rs
@@ -7,5 +7,5 @@ use crucible::*;
 pub fn f() {
     // This call should be replaced by the test override
     let foo = crucible_i8("x");
-    crucible_assert!(foo + 1 != foo);
+    crucible_assert!(foo.wrapping_add(1) != foo);
 }

--- a/test/symb_eval/overrides/override4.good
+++ b/test/symb_eval/overrides/override4.good
@@ -1,8 +1,8 @@
 test override4/3a1fbbbh::f[0]: ok
 
 [Crux] Goal status:
-[Crux]   Total: 1
-[Crux]   Proved: 1
+[Crux]   Total: 2
+[Crux]   Proved: 2
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/overrides/override5.good
+++ b/test/symb_eval/overrides/override5.good
@@ -4,7 +4,7 @@ failures:
 
 ---- override5/3a1fbbbh::f[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/overrides/override5.rs:11:5:
-	foo + 1 != 0
+	foo.wrapping_add(1) != 0
 in override5/3a1fbbbh::f[0] at <::crucible::crucible_assert macros>:2:42: 2:62
 
 [Crux] Goal status:

--- a/test/symb_eval/overrides/override5.rs
+++ b/test/symb_eval/overrides/override5.rs
@@ -8,5 +8,5 @@ pub fn f() {
     // This call should be replaced by the test override
     let foo = crucible_u64("foo");
     crucible_assume!(foo != 0);
-    crucible_assert!(foo + 1 != 0);
+    crucible_assert!(foo.wrapping_add(1) != 0);
 }

--- a/test/symb_eval/scalar/test1.good
+++ b/test/symb_eval/scalar/test1.good
@@ -1,8 +1,8 @@
 test test1/3a1fbbbh::f[0]: ok
 
 [Crux] Goal status:
-[Crux]   Total: 77
-[Crux]   Proved: 77
+[Crux]   Total: 94
+[Crux]   Proved: 94
 [Crux]   Disproved: 0
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0

--- a/test/symb_eval/sym_bytes/deserialize.good
+++ b/test/symb_eval/sym_bytes/deserialize.good
@@ -1,9 +1,15 @@
-test deserialize/3a1fbbbh::crux_test[0]: returned Symbolic BV, ok
+test deserialize/3a1fbbbh::crux_test[0]: returned Symbolic BV, FAILED
+
+failures:
+
+---- deserialize/3a1fbbbh::crux_test[0] counterexamples ----
+Failure for attempt to add with overflow
+in deserialize/3a1fbbbh::deserialize[0] at test/symb_eval/sym_bytes/deserialize.rs:20:21
 
 [Crux] Goal status:
-[Crux]   Total: 1
-[Crux]   Proved: 1
-[Crux]   Disproved: 0
+[Crux]   Total: 3
+[Crux]   Proved: 2
+[Crux]   Disproved: 1
 [Crux]   Incomplete: 0
 [Crux]   Unknown: 0
-[Crux] Overall status: Valid.
+[Crux] Overall status: Invalid.


### PR DESCRIPTION
Implements panic on arithmetic overflow, as in Rust's default debug configuration.  With overflow checks turned on, `rustc` compiles arithmetic to a MIR `CheckedBinOp`, which produces both a result and an overflow flag, followed by an `Assert` to panic if the flag indicates that overflow occurred.  Both parts were previously unimplemented: `CheckedBinOp` always returned `false` for the overflow flag, and `Assert` was a no-op.

This branch only implements overflow checks for `Add`, `Sub`, and shift operators.  `Mul`, `Div`, and `Rem` are still unsupported (never indicate overflow) since their overflow conditions are a bit more complex to express.