### PR TITLE
Memory model improvements (Part 1.5)

### DIFF
--- a/lib/crucible/alloc.rs
+++ b/lib/crucible/alloc.rs
@@ -2,3 +2,9 @@
 pub fn allocate<T>(len: usize) -> *mut T {
     unimplemented!("allocate")
 }
+
+/// Reallocate the array at `*ptr` to contain `new_len` elements.  This reallocation always happens
+/// in-place and never fails, so there is no need to return a new pointer.
+pub fn reallocate<T>(ptr: *mut T, new_len: usize) {
+    unimplemented!("reallocate")
+}

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -655,6 +655,13 @@ mirVector_fromArray ::
     MirGenerator h s ret (R.Expr MIR s (MirVectorType (C.BaseToType btp)))
 mirVector_fromArray tpr a = G.extensionStmt $ MirVector_FromArray tpr a
 
+mirVector_resize ::
+    C.TypeRepr tp ->
+    R.Expr MIR s (MirVectorType tp) ->
+    R.Expr MIR s UsizeType ->
+    MirGenerator h s ret (R.Expr MIR s (MirVectorType tp))
+mirVector_resize tpr vec len = G.extensionStmt $ MirVector_Resize tpr vec len
+
 
 
 

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -641,21 +641,6 @@ mirVector_fromArray ::
     MirGenerator h s ret (R.Expr MIR s (MirVectorType (C.BaseToType btp)))
 mirVector_fromArray tpr a = G.extensionStmt $ MirVector_FromArray tpr a
 
-mirVector_lookup ::
-    C.TypeRepr tp ->
-    R.Expr MIR s (MirVectorType tp) ->
-    R.Expr MIR s UsizeType ->
-    MirGenerator h s ret (R.Expr MIR s tp)
-mirVector_lookup tpr v i = G.extensionStmt $ MirVector_Lookup tpr v i
-
-mirVector_update ::
-    C.TypeRepr tp ->
-    R.Expr MIR s (MirVectorType tp) ->
-    R.Expr MIR s UsizeType ->
-    R.Expr MIR s tp ->
-    MirGenerator h s ret (R.Expr MIR s (MirVectorType tp))
-mirVector_update tpr v i x = G.extensionStmt $ MirVector_Update tpr v i x
-
 
 
 

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -565,6 +565,14 @@ mirRef_tryOffsetFrom ::
   MirGenerator h s ret (R.Expr MIR s (C.MaybeType IsizeType))
 mirRef_tryOffsetFrom r1 r2 = G.extensionStmt $ MirRef_TryOffsetFrom r1 r2
 
+mirRef_peelIndex ::
+  C.TypeRepr tp ->
+  R.Expr MIR s (MirReferenceType tp) ->
+  MirGenerator h s ret (R.Expr MIR s (MirReferenceType (MirVectorType tp)), R.Expr MIR s UsizeType)
+mirRef_peelIndex tpr ref = do
+    pair <- G.extensionStmt $ MirRef_PeelIndex tpr ref
+    return (S.getStruct i1of2 pair, S.getStruct i2of2 pair)
+
 -----------------------------------------------------------------------
 
 

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -302,6 +302,9 @@ instance Monoid CollectionState where
 instance Show (MirExp s) where
     show (MirExp tr e) = (show e) ++ ": " ++ (show tr)
 
+instance Show (MirPlace s) where
+    show (MirPlace tr e m) = show e ++ ", " ++ show m ++ ": & " ++ show tr
+
 instance Show MirHandle where
     show (MirHandle _nm sig c) =
       show c ++ ":" ++ show sig

--- a/src/Mir/Generator.hs
+++ b/src/Mir/Generator.hs
@@ -559,6 +559,12 @@ mirRef_offsetWrap ::
   MirGenerator h s ret (R.Expr MIR s (MirReferenceType tp))
 mirRef_offsetWrap tpr ref offset = G.extensionStmt $ MirRef_OffsetWrap tpr ref offset
 
+mirRef_tryOffsetFrom ::
+  R.Expr MIR s (MirReferenceType tp) ->
+  R.Expr MIR s (MirReferenceType tp) ->
+  MirGenerator h s ret (R.Expr MIR s (C.MaybeType IsizeType))
+mirRef_tryOffsetFrom r1 r2 = G.extensionStmt $ MirRef_TryOffsetFrom r1 r2
+
 -----------------------------------------------------------------------
 
 

--- a/src/Mir/Intrinsics.hs
+++ b/src/Mir/Intrinsics.hs
@@ -273,6 +273,9 @@ isizeDiv = BVSdiv knownRepr
 isizeRem :: f IsizeType -> f IsizeType -> App ext f IsizeType
 isizeRem = BVSrem knownRepr
 
+isizeNeg :: f IsizeType -> App ext f IsizeType
+isizeNeg = BVNeg knownRepr
+
 isizeAnd :: f IsizeType -> f IsizeType -> App ext f IsizeType
 isizeAnd = BVAnd knownRepr
 

--- a/src/Mir/Intrinsics.hs
+++ b/src/Mir/Intrinsics.hs
@@ -416,6 +416,16 @@ data MirReference sym (tp :: CrucibleType) where
     !(RegValue sym UsizeType) ->
     MirReference sym tp
 
+instance IsSymInterface sym => Show (MirReferencePath sym tp tp') where
+    show Empty_RefPath = "Empty_RefPath"
+    show (Any_RefPath tpr p) = "(Any_RefPath " ++ show tpr ++ " " ++ show p ++ ")"
+    show (Field_RefPath ctx p idx) = "(Field_RefPath " ++ show ctx ++ " " ++ show p ++ " " ++ show idx ++ ")"
+    show (Variant_RefPath ctx p idx) = "(Variant_RefPath " ++ show ctx ++ " " ++ show p ++ " " ++ show idx ++ ")"
+    show (Index_RefPath tpr p idx) = "(Index_RefPath " ++ show tpr ++ " " ++ show p ++ " " ++ show (printSymExpr idx) ++ ")"
+    show (Just_RefPath tpr p) = "(Just_RefPath " ++ show tpr ++ " " ++ show p ++ ")"
+    show (VectorAsMirVector_RefPath tpr p) = "(VectorAsMirVector_RefPath " ++ show tpr ++ " " ++ show p ++ ")"
+    show (ArrayAsMirVector_RefPath btpr p) = "(ArrayAsMirVector_RefPath " ++ show btpr ++ " " ++ show p ++ ")"
+
 refRootType :: MirReferenceRoot sym tp -> TypeRepr tp
 refRootType (RefCell_RefRoot r) = refType r
 refRootType (GlobalVar_RefRoot r) = globalType r

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -766,14 +766,7 @@ mkTraitObject traitName vtableName e = do
 evalRval :: HasCallStack => M.Rvalue -> MirGenerator h s ret (MirExp s)
 evalRval (M.Use op) = evalOperand op
 evalRval (M.Repeat op size) = buildRepeat op size
-evalRval (M.Ref bk lv _) =
-  case bk of
-    -- TODO: This discards path information: addrOfPlaceRef reads the value,
-    -- then makes a new ref with Empty_RefPath.  This will break offsetting in
-    -- the case of `let ptr = &xs[0] as *const _; ptr.offset(1)`.
-    M.Shared  -> evalPlace lv >>= addrOfPlace
-    M.Mutable -> evalPlace lv >>= addrOfPlace
-    M.Unique  -> evalPlace lv >>= addrOfPlace
+evalRval (M.Ref _bk lv _) = evalPlace lv >>= addrOfPlace
 evalRval (M.Len lv) =
     case M.typeOf lv of
         M.TyArray _ len ->

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -744,8 +744,9 @@ slice_to_array = (["core","array", "slice_to_array"],
                 let args = Substs [TyArray ty 0]
                 MirExp C.AnyRepr <$> G.ifte lenOk
                     (do v <- vectorCopy tpr ptr len
-                        ref <- constMirRef (C.VectorRepr tpr) v
-                        let vMir = MirExp (MirReferenceRepr (C.VectorRepr tpr)) ref
+                        v' <- mirVector_fromVector tpr v
+                        ref <- constMirRef (MirVectorRepr tpr) v'
+                        let vMir = MirExp (MirReferenceRepr (MirVectorRepr tpr)) ref
                         enum <- buildEnum adt args optionDiscrSome [vMir]
                         unwrapMirExp C.AnyRepr enum)
                     (do enum <- buildEnum adt args optionDiscrNone []

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -100,6 +100,7 @@ customOpDefs = Map.fromList $ [
                          , saturating_sub
                          , ctlz
                          , ctlz_nonzero
+                         , min_align_of
 
                          , mem_crucible_identity_transmute
                          , slice_to_array
@@ -844,7 +845,6 @@ ctlz_nonzero =
     ( ["core","intrinsics", "", "ctlz_nonzero"]
     , ctlz_impl "ctlz_nonzero" Nothing )
 
-
 ---------------------------------------------------------------------------------------
 -- ** Custom ::intrinsics::discriminant_value
 
@@ -865,6 +865,13 @@ type_id = (["core","intrinsics", "", "type_id"],
   \ _substs -> Just $ CustomOp $ \ opTys ops ->
     -- TODO: keep a map from Ty to Word64, assigning IDs on first use of each type
     return $ MirExp knownRepr $ R.App (E.BVLit (knownRepr :: NatRepr 64) 0))
+
+min_align_of :: (ExplodedDefId, CustomRHS)
+min_align_of = (["core", "intrinsics", "", "min_align_of"], \substs -> case substs of
+    Substs [t] -> Just $ CustomOp $ \_ _ ->
+        -- TODO: return the actual alignment, once mir-json exports size/layout info
+        return $ MirExp UsizeRepr $ R.App $ usizeLit 1
+    )
 
 -- mem::swap is used pervasively (both directly and via mem::replace), but it
 -- has a nasty unsafe implementation, with lots of raw pointers and

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -100,6 +100,7 @@ customOpDefs = Map.fromList $ [
                          , saturating_sub
                          , ctlz
                          , ctlz_nonzero
+                         , size_of
                          , min_align_of
 
                          , mem_crucible_identity_transmute
@@ -845,6 +846,7 @@ ctlz_nonzero =
     ( ["core","intrinsics", "", "ctlz_nonzero"]
     , ctlz_impl "ctlz_nonzero" Nothing )
 
+
 ---------------------------------------------------------------------------------------
 -- ** Custom ::intrinsics::discriminant_value
 
@@ -865,6 +867,13 @@ type_id = (["core","intrinsics", "", "type_id"],
   \ _substs -> Just $ CustomOp $ \ opTys ops ->
     -- TODO: keep a map from Ty to Word64, assigning IDs on first use of each type
     return $ MirExp knownRepr $ R.App (E.BVLit (knownRepr :: NatRepr 64) 0))
+
+size_of :: (ExplodedDefId, CustomRHS)
+size_of = (["core", "intrinsics", "", "size_of"], \substs -> case substs of
+    Substs [t] -> Just $ CustomOp $ \_ _ ->
+        -- TODO: return the actual size, once mir-json exports size/layout info
+        return $ MirExp UsizeRepr $ R.App $ usizeLit 1
+    )
 
 min_align_of :: (ExplodedDefId, CustomRHS)
 min_align_of = (["core", "intrinsics", "", "min_align_of"], \substs -> case substs of

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -132,6 +132,8 @@ customOpDefs = Map.fromList $ [
                          , ptr_wrapping_offset
                          , ptr_offset_from
                          , ptr_is_null
+                         , ptr_slice_from_raw_parts
+                         , ptr_slice_from_raw_parts_mut
 
                          , ptr_read
                          , ptr_write
@@ -490,6 +492,23 @@ ptr_is_null_impl = \substs -> case substs of
 
 ptr_is_null :: (ExplodedDefId, CustomRHS)
 ptr_is_null = (["core", "ptr", "{{impl}}", "is_null"], ptr_is_null_impl)
+
+ptr_slice_from_raw_parts_impl :: CustomRHS
+ptr_slice_from_raw_parts_impl = \substs -> case substs of
+    Substs [_] -> Just $ CustomOp $ \_ ops -> case ops of
+        [MirExp (MirReferenceRepr tpr) ptr, MirExp UsizeRepr len] ->
+            return $ MirExp (MirSliceRepr tpr) (mkSlice tpr ptr len)
+        _ -> mirFail $ "bad arguments for ptr::slice_from_raw_parts: " ++ show ops
+    _ -> Nothing
+
+ptr_slice_from_raw_parts :: (ExplodedDefId, CustomRHS)
+ptr_slice_from_raw_parts =
+    ( ["core", "ptr", "slice_from_raw_parts"]
+    , ptr_slice_from_raw_parts_impl)
+ptr_slice_from_raw_parts_mut :: (ExplodedDefId, CustomRHS)
+ptr_slice_from_raw_parts_mut =
+    ( ["core", "ptr", "slice_from_raw_parts_mut"]
+    , ptr_slice_from_raw_parts_impl)
 
 
 ptr_read :: (ExplodedDefId, CustomRHS)

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -102,6 +102,7 @@ customOpDefs = Map.fromList $ [
                          , ctlz_nonzero
                          , size_of
                          , min_align_of
+                         , intrinsics_assume
 
                          , mem_crucible_identity_transmute
                          , slice_to_array
@@ -912,6 +913,15 @@ mem_crucible_identity_transmute = (["core","mem", "crucible_identity_transmute"]
         _ -> mirFail $ "bad arguments to mem_crucible_identity_transmute: "
           ++ show (tyT, tyU, ops)
       _ -> Nothing
+    )
+
+intrinsics_assume :: (ExplodedDefId, CustomRHS)
+intrinsics_assume = (["core", "intrinsics", "", "assume"], \_substs ->
+    Just $ CustomOp $ \_ ops -> case ops of
+        [MirExp C.BoolRepr cond] -> do
+            G.assertExpr cond $
+                S.litExpr "undefined behavior: core::intrinsics::assume(false)"
+            return $ MirExp C.UnitRepr $ R.App E.EmptyApp
     )
 
 slice_to_array ::  (ExplodedDefId, CustomRHS)

--- a/src/Mir/TransTy.hs
+++ b/src/Mir/TransTy.hs
@@ -181,15 +181,14 @@ tyToRepr t0 = case t0 of
   M.TyRef (M.TyDynamic _ _) _ -> Some $ C.StructRepr $
     Ctx.empty Ctx.:> C.AnyRepr Ctx.:> C.AnyRepr
 
-  M.TyRawPtr (M.TyDynamic _ _) _ -> Some $ C.StructRepr $
-    Ctx.empty Ctx.:> C.AnyRepr Ctx.:> C.AnyRepr
-
   -- TODO: DSTs not behind a reference - these should never appear in real code
   M.TySlice t -> tyToReprCont t $ \repr -> Some (MirSliceRepr repr)
   M.TyStr -> Some (MirSliceRepr (C.BVRepr (knownNat :: NatRepr 8)))
 
   M.TyRef t _       -> tyToReprCont t $ \repr -> Some (MirReferenceRepr repr)
-  M.TyRawPtr t _    -> tyToReprCont t $ \repr -> Some (MirReferenceRepr repr)
+  -- Raw pointers are represented like references, including the fat pointer
+  -- cases that are special-cased above.
+  M.TyRawPtr t mutbl -> tyToRepr (M.TyRef t mutbl)
 
   M.TyChar -> Some $ C.BVRepr (knownNat :: NatRepr 32) -- rust chars are four bytes
 

--- a/src/Mir/TransTy.hs
+++ b/src/Mir/TransTy.hs
@@ -58,9 +58,11 @@ import           Mir.PP (fmt)
 import           Mir.Generator 
     ( MirExp(..), MirPlace(..), PtrMetadata(..), MirGenerator, mirFail
     , subanyRef, subfieldRef, subvariantRef, subjustRef
+    , mirVector_fromVector
     , cs, discrMap )
 import           Mir.Intrinsics
     ( MIR, pattern MirSliceRepr, pattern MirReferenceRepr, MirReferenceType
+    , pattern MirVectorRepr
     , SizeBits, pattern UsizeRepr, pattern IsizeRepr
     , isizeLit
     , RustEnumType, pattern RustEnumRepr, mkRustEnum, rustEnumVariant, rustEnumDiscriminant
@@ -160,7 +162,7 @@ tyToRepr t0 = case t0 of
   -- Closures are just tuples with a fancy name
   M.TyClosure ts  -> tyListToCtxMaybe ts $ \repr -> Some (C.StructRepr repr)
 
-  M.TyArray t _sz -> tyToReprCont t $ \repr -> Some (C.VectorRepr repr)
+  M.TyArray t _sz -> tyToReprCont t $ \repr -> Some (MirVectorRepr repr)
 
   M.TyInt M.USize  -> Some IsizeRepr
   M.TyUint M.USize -> Some UsizeRepr
@@ -379,15 +381,16 @@ unpackAnyC _ (MirExp tpr' _) = error $ "bad anytype unpack of " ++ show tpr'
 buildArrayLit :: forall h s tp ret.  C.TypeRepr tp -> [MirExp s] -> MirGenerator h s ret (MirExp s)
 buildArrayLit trep exps = do
     vec <- go exps V.empty
-    return $ MirExp (C.VectorRepr trep) $  S.app $ E.VectorLit trep vec
-        where go :: [MirExp s] -> V.Vector (R.Expr MIR s tp) -> MirGenerator h s ret (V.Vector (R.Expr MIR s tp))
-              go [] v = return v
-              go ((MirExp erepr e):es) v = do
-                case (testEquality erepr trep) of
-                  Just Refl -> do
-                      v' <- go es v
-                      return $ V.cons e v'
-                  Nothing -> mirFail "bad type in build array"
+    exp <- mirVector_fromVector trep $ S.app $ E.VectorLit trep vec
+    return $ MirExp (MirVectorRepr trep) exp
+  where go :: [MirExp s] -> V.Vector (R.Expr MIR s tp) -> MirGenerator h s ret (V.Vector (R.Expr MIR s tp))
+        go [] v = return v
+        go ((MirExp erepr e):es) v = do
+          case (testEquality erepr trep) of
+            Just Refl -> do
+                v' <- go es v
+                return $ V.cons e v'
+            Nothing -> mirFail "bad type in build array"
 
 buildTuple :: [MirExp s] -> MirExp s
 buildTuple xs = exp_to_assgn (xs) $ \ctx asgn ->

--- a/test/conc_eval/ptr/coerce_unsized.rs
+++ b/test/conc_eval/ptr/coerce_unsized.rs
@@ -1,0 +1,23 @@
+#![feature(custom_attribute)]
+#![feature(unsize)]
+#![feature(coerce_unsized)]
+use std::marker::Unsize;
+use std::ops::CoerceUnsized;
+use std::ptr;
+
+struct MyPtr<T: ?Sized>(*const T);
+impl<T: Unsize<U> + ?Sized, U: ?Sized> CoerceUnsized<MyPtr<U>> for MyPtr<T> {}
+
+#[crux_test]
+fn crux_test() -> (i32, i32) {
+    let a = [1, 2];
+    let arr_ptr = MyPtr(&a as *const [i32; 2]);
+    // This cast requires CoerceUnsized
+    let slice_ptr = arr_ptr as MyPtr<[i32]>;
+    let ptr = slice_ptr.0 as *const i32;
+    unsafe { (*ptr, *ptr.offset(1)) }
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/copy.rs
+++ b/test/conc_eval/ptr/copy.rs
@@ -1,0 +1,17 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() -> [i32; 6] {
+    let a = [1, 2, 3];
+    let mut b = [0; 6];
+    unsafe {
+        ptr::copy(&a[0], &mut b[0], 3);
+        ptr::copy_nonoverlapping(&b[0], &mut b[3], 3);
+    }
+    b
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/dangling_eq.rs
+++ b/test/conc_eval/ptr/dangling_eq.rs
@@ -1,4 +1,3 @@
-// FAIL: core::intrinsics::min_align_of not yet implemented
 #![feature(custom_attribute)]
 use std::ptr;
 

--- a/test/conc_eval/ptr/is_null.rs
+++ b/test/conc_eval/ptr/is_null.rs
@@ -1,0 +1,13 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() -> (bool, bool) {
+    let p = &1 as *const i32;
+    let q = 0 as *const i32;
+    (p.is_null(), q.is_null())
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/is_null_slice.rs
+++ b/test/conc_eval/ptr/is_null_slice.rs
@@ -1,0 +1,14 @@
+// FAIL: can't unsize null pointers
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() -> (bool, bool) {
+    let p = &[1, 2] as *const [i32; 2] as *const [i32];
+    let q = 0 as *const [i32; 2] as *const [i32];
+    (p.is_null(), q.is_null())
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/offset_from.rs
+++ b/test/conc_eval/ptr/offset_from.rs
@@ -1,0 +1,13 @@
+#![feature(custom_attribute)]
+#![feature(ptr_offset_from)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() -> isize {
+    let a = [1, 2, 3];
+    unsafe { (&a[0] as *const i32).offset_from(&a[2] as *const _) }
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/read_write.rs
+++ b/test/conc_eval/ptr/read_write.rs
@@ -1,0 +1,20 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() -> [i32; 3] {
+    let mut a = [1, 2, 3];
+    unsafe {
+        let p0 = &mut a[0] as *mut _;
+        let p1 = &mut a[1] as *mut _;
+        let p2 = &mut a[2] as *mut _;
+        let x = ptr::read(p0);
+        ptr::write(p1, x);
+        ptr::swap(p1, p2);
+    }
+    a
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/struct_eq.rs
+++ b/test/conc_eval/ptr/struct_eq.rs
@@ -1,0 +1,20 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+struct Foo {
+    x: i32,
+    y: i32,
+}
+
+#[crux_test]
+fn crux_test() {
+    let a = Foo { x: 1, y: 1 };
+    let b = Foo { x: 1, y: 1 };
+    assert!(&a.x as *const _ == &a.x as *const _);
+    assert!(&a.x as *const _ != &a.y as *const _);
+    assert!(&a.x as *const _ != &b.x as *const _);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/unsize_slice.rs
+++ b/test/conc_eval/ptr/unsize_slice.rs
@@ -1,0 +1,14 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() -> (i32, i32) {
+    let a = [1, 2];
+    let slice_ptr = &a as *const [i32];
+    let ptr = slice_ptr as *const i32;
+    unsafe { (*ptr, *ptr.offset(1)) }
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/ptr/valid_eq.rs
+++ b/test/conc_eval/ptr/valid_eq.rs
@@ -1,0 +1,14 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+fn crux_test() {
+    let x = 1;
+    let y = 2;
+    assert!(&x as *const _ == &x as *const _);
+    assert!(&x as *const _ != &y as *const _);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/conc_eval/slice/swap.rs
+++ b/test/conc_eval/slice/swap.rs
@@ -1,0 +1,18 @@
+#![feature(custom_attribute)]
+use std::ptr;
+
+#[crux_test]
+pub fn f() -> i32 {
+    let mut v = [1, 2];
+    unsafe {
+        // This mimics the swap operation used in the normal slice::sort implementation.  (But note
+        // the real version uses a `Drop` impl for the final copy, which we don't support.)
+        let tmp = ptr::read(&v[0]);
+        ptr::copy_nonoverlapping(&v[1], &mut v[0], 1);
+        ptr::copy_nonoverlapping(&tmp, &mut v[1], 1);
+    }
+    v[0] * 1000 + v[1]
+}
+
+
+fn main() { println!("{:?}", f()); }


### PR DESCRIPTION
Followup to #19.  This is mostly support for a bunch of new intrinsics and a few new kinds of casts, which are all used in the standard library implementations of `Vec`, `slice`, and other essentials.  We previously used extensive patches to the standard library to work around our lack of support for these features, but as part of the upgrade to rust nightly-2020-03-22, we are switching back to the unmodified upstream versions whenever possible in order to reduce future maintenance burden.

The most interesting thing happening in this branch is the representation change for array types.  The purpose of the change is to support `reallocate` on heap-allocated arrays, which happens as part of `vec![1, 2, 3].push(4)`.  Previously, arrays were `VectorType`, though they were commonly wrapped in `MirVector_Vector` to convert them to `MirVectorType`, as `MirVectorType` is used in the slice representation.  Now, arrays are directly represented as `MirVectorType`, with no wrapping needed.  The benefit is that it's now possible to switch from the initial `MirVector_Vector` variant (a wrapper around `VectorType t`, where all items are initialized) to `MirVector_PartialVector` (`VectorType (MaybeType t)`, so some items can be uninitialized).  `reallocate` does this in order to extend an array with additional uninitialized slots.

For reference, the behavior of `vec![1, 2, 3].push(4)` is approximately:
```Rust
let arr = Box::new([1, 2, 3]);  // Heap-allocate an array
let ptr = Box::into_raw(arr) as *mut i32;  // Convert to a raw pointer to the first element
let ptr = reallocate(ptr, 6);  // Double the length of the allocation
*ptr.offset(3) = 4;  // Store the new value in position 3
```