### PR TITLE
Add support for destructors

### DIFF
--- a/lib/crucible/lib.rs
+++ b/lib/crucible/lib.rs
@@ -6,6 +6,7 @@ pub mod alloc;
 pub use core::crucible::any;
 pub mod array;
 pub mod bitvector;
+pub use core::crucible::ptr;
 pub mod symbolic;
 pub mod sym_bytes;
 pub mod vector;

--- a/lib/liballoc/alloc.rs
+++ b/lib/liballoc/alloc.rs
@@ -236,14 +236,8 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
 // well.
 // For example if `Box` is changed to  `struct Box<T: ?Sized, A: AllocRef>(Unique<T>, A)`,
 // this function has to be changed to `fn box_free<T: ?Sized, A: AllocRef>(Unique<T>, A)` as well.
-pub(crate) unsafe fn box_free<T: ?Sized>(ptr: Unique<T>) {
-    let size = size_of_val(ptr.as_ref());
-    let align = min_align_of_val(ptr.as_ref());
-    // We do not allocate for Box<T> when T is ZST, so deallocation is also not necessary.
-    if size != 0 {
-        let layout = Layout::from_size_align_unchecked(size, align);
-        Global.dealloc(ptr.cast().into(), layout);
-    }
+pub(crate) unsafe fn box_free<T: ?Sized>(_ptr: Unique<T>) {
+    // Crux: currently we don't implement `deallocate`, so this is a no-op.
 }
 
 /// Abort on memory allocation error or failure.

--- a/lib/liballoc/lib.rs
+++ b/lib/liballoc/lib.rs
@@ -88,6 +88,7 @@
 #![feature(const_in_array_repeat_expressions)]
 #![feature(const_if_match)]
 #![feature(cow_is_borrowed)]
+#![feature(crucible_intrinsics)]
 #![feature(dispatch_from_dyn)]
 #![feature(core_intrinsics)]
 #![feature(container_error_extra)]

--- a/lib/liballoc/rc.rs
+++ b/lib/liballoc/rc.rs
@@ -251,6 +251,7 @@ use core::pin::Pin;
 use core::ptr::{self, NonNull};
 use core::slice::{self, from_raw_parts_mut};
 use core::usize;
+use crucible;
 
 use crate::alloc::{box_free, handle_alloc_error, AllocRef, Global, Layout};
 use crate::string::String;
@@ -1768,8 +1769,7 @@ impl<T> Weak<T> {
 }
 
 pub(crate) fn is_dangling<T: ?Sized>(ptr: NonNull<T>) -> bool {
-    let address = ptr.as_ptr() as *mut () as usize;
-    address == usize::MAX
+    crucible::ptr::compare_usize(ptr.as_ptr(), usize::MAX)
 }
 
 impl<T: ?Sized> Weak<T> {

--- a/lib/liballoc/sync.rs
+++ b/lib/liballoc/sync.rs
@@ -757,7 +757,7 @@ impl<T: ?Sized> Arc<T> {
 
         if self.inner().weak.fetch_sub(1, Release) == 1 {
             acquire!(self.inner().weak);
-            Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()))
+            // Crux: we should deallocate `self.ptr` here, but we don't support `deallocate` yet.
         }
     }
 

--- a/lib/libcore/crucible/mod.rs
+++ b/lib/libcore/crucible/mod.rs
@@ -2,3 +2,6 @@
 //! `libcrucible` so users have a more consistent API.
 #[unstable(feature = "crucible_intrinsics", issue = "none")]
 pub mod any;
+
+#[unstable(feature = "crucible_intrinsics", issue = "none")]
+pub mod ptr;

--- a/lib/libcore/crucible/ptr.rs
+++ b/lib/libcore/crucible/ptr.rs
@@ -1,0 +1,8 @@
+//! Crucible pointer intrinsics used within libcore.
+
+/// Pointer-to-usize comparison.  Unlike `ptr as usize == val`, this works on fat pointers and
+/// valid pointers too (pointers not created via integer-to-pointer casts).
+#[unstable(feature = "crucible_intrinsics", issue = "none")]
+pub fn compare_usize<T: ?Sized>(ptr: *const T, val: usize) -> bool {
+    unimplemented!("ptr::compare_usize")
+}

--- a/lib/libcore/ptr/const_ptr.rs
+++ b/lib/libcore/ptr/const_ptr.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
+use crate::crucible;
 use crate::intrinsics;
 use crate::mem;
 
@@ -26,9 +27,7 @@ impl<T: ?Sized> *const T {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_null(self) -> bool {
-        // Compare via a cast to a thin pointer, so fat pointers are only
-        // considering their "data" part for null-ness.
-        (self as *const u8) == null()
+        crucible::ptr::compare_usize(self, 0)
     }
 
     /// Casts to a pointer of another type.

--- a/lib/libcore/ptr/mut_ptr.rs
+++ b/lib/libcore/ptr/mut_ptr.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
+use crate::crucible;
 use crate::intrinsics;
 
 // ignore-tidy-undocumented-unsafe
@@ -25,9 +26,7 @@ impl<T: ?Sized> *mut T {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn is_null(self) -> bool {
-        // Compare via a cast to a thin pointer, so fat pointers are only
-        // considering their "data" part for null-ness.
-        (self as *mut u8) == null_mut()
+        crucible::ptr::compare_usize(self, 0)
     }
 
     /// Casts to a pointer of another type.

--- a/src/Mir/JSON.hs
+++ b/src/Mir/JSON.hs
@@ -301,8 +301,8 @@ instance FromJSON Terminator where
                                                   Just (String "Abort") -> pure Abort
                                                   Just (String "Return") -> pure Return
                                                   Just (String "Unreachable") -> pure Unreachable
-                                                  Just (String "Drop") -> Drop <$> v .: "location" <*> v .: "target" <*> v .: "unwind"
-                                                  Just (String "DropAndReplace") -> DropAndReplace <$> v .: "location" <*> v .: "value" <*> v .: "target" <*> v .: "unwind"
+                                                  Just (String "Drop") -> Drop <$> v .: "location" <*> v .: "target" <*> v .: "unwind" <*> v .: "drop_fn"
+                                                  Just (String "DropAndReplace") -> DropAndReplace <$> v .: "location" <*> v .: "value" <*> v .: "target" <*> v .: "unwind" <*> v .: "drop_fn"
                                                   Just (String "Call") ->  Call <$> v .: "func" <*> v .: "args" <*> v .: "destination" <*> v .: "cleanup"
                                                   Just (String "Assert") -> Assert <$> v .: "cond" <*> v .: "expected" <*> v .: "msg" <*> v .: "target" <*> v .: "cleanup"
                                                   k -> fail $ "unsupported terminator" ++ show k

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -366,6 +366,9 @@ data Operand =
         Copy Lvalue
       | Move Lvalue
       | OpConstant Constant
+      -- | The result of evaluating an Rvalue.  This never appears in
+      -- rustc-generated MIR, but we produce them internally in some cases.
+      | Temp Rvalue
       deriving (Show, Eq, Ord, Generic)
 
 data NullOp =
@@ -681,6 +684,7 @@ instance TypeOf Operand where
     typeOf (Move lv) = typeOf lv
     typeOf (Copy lv) = typeOf lv
     typeOf (OpConstant c) = typeOf c
+    typeOf (Temp rv) = typeOf rv
 
 instance TypeOf Constant where
     typeOf (Constant a _b) = a

--- a/src/Mir/Mir.hs
+++ b/src/Mir/Mir.hs
@@ -340,11 +340,17 @@ data Terminator =
       | Unreachable
       | Drop { _dloc    :: Lvalue,
                _dtarget :: BasicBlockInfo,
-               _dunwind :: Maybe BasicBlockInfo }
+               _dunwind :: Maybe BasicBlockInfo,
+               -- | The DefId of the `drop_in_place` implementation for the
+               -- type being dropped.  `Nothing` indicates the type has no
+               -- custom drop implementation (and neither do its fields,
+               -- transitively).
+               _ddrop_fn :: Maybe MethName }
       | DropAndReplace { _drloc    :: Lvalue,
                          _drval    :: Operand,
                          _drtarget :: BasicBlockInfo,
-                         _drunwind :: Maybe BasicBlockInfo }
+                         _drunwind :: Maybe BasicBlockInfo,
+                         _drdrop_fn :: Maybe MethName }
       | Call { _cfunc   :: Operand,
                _cargs   :: [Operand],
                _cdest   :: Maybe (Lvalue, BasicBlockInfo),

--- a/src/Mir/PP.hs
+++ b/src/Mir/PP.hs
@@ -229,6 +229,7 @@ instance Pretty Operand where
     pretty (OpConstant c) = pretty c
     pretty (Move c) = pretty c
     pretty (Copy c) = pretty c
+    pretty (Temp c) = pretty c
 
 instance Pretty Constant where
     pretty (Constant _a b) = pretty b

--- a/src/Mir/PP.hs
+++ b/src/Mir/PP.hs
@@ -205,8 +205,11 @@ instance Pretty Terminator where
     pretty Abort = text "abort;"
     pretty Resume = text "resume;"
     pretty Unreachable = text "unreachable;"
-    pretty (Drop _l _target _unwind) = text "drop;"
-    pretty DropAndReplace{} = text "dropreplace;"
+    pretty (Drop l target _unwind dropFn) =
+        text "drop" <+> pretty l <+> text "->" <+> pretty target <+> parens (text $ show dropFn) <> semi
+    pretty (DropAndReplace l r target _unwind dropFn) =
+        text "dropreplace" <+> pretty l <+> equals <+> pretty r <+>
+            text "->" <+> pretty target <+> parens (text $ show dropFn) <> semi
     pretty (Call f args (Just (lv,bb0)) bb1) =
       text "call" <> tupled ([pretty lv <+> text "="
                                        <+> pretty f <> tupled (map pretty args),

--- a/src/Mir/Trans.hs
+++ b/src/Mir/Trans.hs
@@ -1319,7 +1319,7 @@ transTerminator (M.SwitchInt swop _swty svals stargs) _ | all Maybe.isJust svals
     transSwitch s (Maybe.catMaybes svals) stargs
 transTerminator (M.Return) tr =
     doReturn tr
-transTerminator (M.DropAndReplace dlv dop dtarg _) _ = do
+transTerminator (M.DropAndReplace dlv dop dtarg _ _dropFn) _ = do
     transStatement (M.Assign dlv (M.Use dop) "<dummy pos>")
     jumpToBlock dtarg
 
@@ -1345,7 +1345,7 @@ transTerminator (M.Assert cond expected msg target _cleanup) _ = do
     jumpToBlock target
 transTerminator (M.Resume) tr =
     doReturn tr -- resume happens when unwinding
-transTerminator (M.Drop _dl dt _dunwind) _ =
+transTerminator (M.Drop _dl dt _dunwind _dropFn) _ = do
     jumpToBlock dt -- FIXME! drop: just keep going
 transTerminator M.Abort tr =
     G.reportError (S.litExpr "process abort in unwinding")

--- a/src/Mir/TransCustom.hs
+++ b/src/Mir/TransCustom.hs
@@ -137,8 +137,7 @@ customOpDefs = Map.fromList $ [
                          , ptr_wrapping_offset_mut
                          , ptr_offset_from
                          , ptr_offset_from_mut
-                         , ptr_is_null
-                         , ptr_is_null_mut
+                         , ptr_compare_usize
                          , is_aligned_and_not_null
                          , ptr_slice_from_raw_parts
                          , ptr_slice_from_raw_parts_mut
@@ -483,27 +482,20 @@ ptr_offset_from = (["core", "ptr", "const_ptr", "{{impl}}", "offset_from"], ptr_
 ptr_offset_from_mut :: (ExplodedDefId, CustomRHS)
 ptr_offset_from_mut = (["core", "ptr", "mut_ptr", "{{impl}}", "offset_from"], ptr_offset_from_impl)
 
--- is_null isn't just `self == ptr::null()`, since it has to work on fat
--- pointers too.  The libcore implementation works by casting to `*const u8` (a
--- thin pointer), but we don't support `*const T -> *const U` casts, so we need
--- this override.
-ptr_is_null_impl :: CustomRHS
-ptr_is_null_impl = \substs -> case substs of
-    Substs [_] -> Just $ CustomOp $ \_ ops -> case ops of
-        [MirExp (MirReferenceRepr tpr) ref] -> do
-            null <- integerToMirRef tpr $ R.App $ usizeLit 0
-            MirExp C.BoolRepr <$> mirRef_eq ref null
-        [MirExp (MirSliceRepr tpr) slice] -> do
-            null <- integerToMirRef tpr $ R.App $ usizeLit 0
-            MirExp C.BoolRepr <$> mirRef_eq (getSlicePtr slice) null
-        -- TODO: `&dyn Tr` case (after defining MirDynRepr)
-        _ -> mirFail $ "bad arguments for ptr::is_null: " ++ show ops
-    _ -> Nothing
-
-ptr_is_null :: (ExplodedDefId, CustomRHS)
-ptr_is_null = (["core", "ptr", "const_ptr", "{{impl}}", "is_null"], ptr_is_null_impl)
-ptr_is_null_mut :: (ExplodedDefId, CustomRHS)
-ptr_is_null_mut = (["core", "ptr", "mut_ptr", "{{impl}}", "is_null"], ptr_is_null_impl)
+ptr_compare_usize :: (ExplodedDefId, CustomRHS)
+ptr_compare_usize = (["core", "crucible", "ptr", "compare_usize"],
+    \substs -> case substs of
+        Substs [_] -> Just $ CustomOp $ \_ ops -> case ops of
+            [MirExp (MirReferenceRepr tpr) ptr, MirExp UsizeRepr val] -> do
+                valAsPtr <- integerToMirRef tpr val
+                MirExp C.BoolRepr <$> mirRef_eq ptr valAsPtr
+            [MirExp (MirSliceRepr tpr) slice, MirExp UsizeRepr val] -> do
+                let ptr = getSlicePtr slice
+                valAsPtr <- integerToMirRef tpr val
+                MirExp C.BoolRepr <$> mirRef_eq ptr valAsPtr
+            -- TODO: `&dyn Tr` case (after defining MirDynRepr)
+            _ -> mirFail $ "bad arguments for ptr::compare_usize: " ++ show ops
+        _ -> Nothing)
 
 is_aligned_and_not_null :: (ExplodedDefId, CustomRHS)
 -- Not an actual intrinsic, so it's not in an `extern` block, so it doesn't

--- a/test/conc_eval/cell/ref_cell2.rs
+++ b/test/conc_eval/cell/ref_cell2.rs
@@ -5,6 +5,10 @@ use std::cell::RefCell;
 #[cfg_attr(crux, crux_test)]
 fn crux_test() -> i32 {
     let x = RefCell::new(1);
+    {
+        // Drop a tuple of Refs.  This requires handling tuple drop glue.
+        let refs = (x.borrow(), x.borrow());
+    }
     *x.borrow_mut() = 2;
     let val = *x.borrow();
     val

--- a/test/conc_eval/clos/conv_fnonce_fn.rs
+++ b/test/conc_eval/clos/conv_fnonce_fn.rs
@@ -1,4 +1,3 @@
-// FAIL: call_once shim
 #![cfg_attr(not(with_main), no_std)]
 pub fn call_it<F: FnOnce(i32) -> i32>(f: F) -> i32 {
     f(1)

--- a/test/conc_eval/clos/conv_fnonce_fnmut.rs
+++ b/test/conc_eval/clos/conv_fnonce_fnmut.rs
@@ -1,4 +1,3 @@
-// FAIL: call_once shim
 #![cfg_attr(not(with_main), no_std)]
 pub fn call_it<F: FnOnce(i32) -> i32>(f: F) -> i32 {
     f(1)

--- a/test/conc_eval/vec/drop.rs
+++ b/test/conc_eval/vec/drop.rs
@@ -1,0 +1,20 @@
+/// Drop a `Vec<T>` where `T: Drop`.  This triggers a call to `drop_in_place::<[T]>`, which uses a
+/// few operations that aren't seen in other drop glues.
+
+struct S(i32);
+
+impl Drop for S {
+    fn drop(&mut self) {
+        // No-op
+    }
+}
+
+#[cfg_attr(crux, crux_test)]
+fn crux_test() {
+    let v = vec![S(1), S(2), S(3)];
+    drop(v);
+}
+
+pub fn main() {
+    println!("{:?}", crux_test());
+}

--- a/test/symb_eval/concretize/assert.good
+++ b/test/symb_eval/concretize/assert.good
@@ -5,7 +5,7 @@ failures:
 ---- assert/3a1fbbbh::crux_test[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/concretize/assert.rs:10:5:
 	100 + 157 == 1
-in assert/3a1fbbbh::crux_test[0] at ./lib/crucible/lib.rs:49:17
+in assert/3a1fbbbh::crux_test[0] at ./lib/crucible/lib.rs:50:17
 
 [Crux] Goal status:
 [Crux]   Total: 1

--- a/test/symb_eval/crux/early_fail.good
+++ b/test/symb_eval/crux/early_fail.good
@@ -10,7 +10,7 @@ in early_fail/3a1fbbbh::fail1[0] at internal
 ---- early_fail/3a1fbbbh::fail2[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/crux/early_fail.rs:17:5:
 	x == 0
-in early_fail/3a1fbbbh::fail2[0] at ./lib/crucible/lib.rs:39:41
+in early_fail/3a1fbbbh::fail2[0] at ./lib/crucible/lib.rs:40:41
 
 [Crux] Goal status:
 [Crux]   Total: 2

--- a/test/symb_eval/crux/multi.good
+++ b/test/symb_eval/crux/multi.good
@@ -15,7 +15,7 @@ in multi/3a1fbbbh::fail2[0] at internal
 ---- multi/3a1fbbbh::fail3[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/crux/multi.rs:20:5:
 	x == 0
-in multi/3a1fbbbh::assert_zero[0] at ./lib/crucible/lib.rs:39:41
+in multi/3a1fbbbh::assert_zero[0] at ./lib/crucible/lib.rs:40:41
 
 [Crux] Goal status:
 [Crux]   Total: 4

--- a/test/symb_eval/crypto/bytes.good
+++ b/test/symb_eval/crypto/bytes.good
@@ -5,19 +5,19 @@ failures:
 ---- bytes/3a1fbbbh::f[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 Failure for MIR assertion at test/symb_eval/crypto/bytes.rs:85:7:
 	a[i] == b[i]
-in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in bytes/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 
 [Crux] Goal status:
 [Crux]   Total: 5

--- a/test/symb_eval/overrides/override2.good
+++ b/test/symb_eval/overrides/override2.good
@@ -5,7 +5,7 @@ failures:
 ---- override2/3a1fbbbh::f[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/overrides/override2.rs:9:5:
 	foo.wrapping_add(1) == foo
-in override2/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in override2/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 
 [Crux] Goal status:
 [Crux]   Total: 1

--- a/test/symb_eval/overrides/override5.good
+++ b/test/symb_eval/overrides/override5.good
@@ -5,7 +5,7 @@ failures:
 ---- override5/3a1fbbbh::f[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/overrides/override5.rs:10:5:
 	foo.wrapping_add(1) != 0
-in override5/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:39:41
+in override5/3a1fbbbh::f[0] at ./lib/crucible/lib.rs:40:41
 
 [Crux] Goal status:
 [Crux]   Total: 1

--- a/test/symb_eval/sym_bytes/construct.good
+++ b/test/symb_eval/sym_bytes/construct.good
@@ -5,7 +5,7 @@ failures:
 ---- construct/3a1fbbbh::crux_test[0] counterexamples ----
 Failure for MIR assertion at test/symb_eval/sym_bytes/construct.rs:13:5:
 	sym2[0] == 0
-in construct/3a1fbbbh::crux_test[0] at ./lib/crucible/lib.rs:39:41
+in construct/3a1fbbbh::crux_test[0] at ./lib/crucible/lib.rs:40:41
 
 [Crux] Goal status:
 [Crux]   Total: 1


### PR DESCRIPTION
This branch adds support for "drop glue" (destructors), which run automatically when values go out of scope.

It turns out `rustc` can provide MIR code for autogenerated drop glue functions, which made this much easier to implement than I previously thought.  See GaloisInc/mir-json#19 for the `mir-json` change that exposes shim MIR in the JSON.
