### PR TITLE
fix compilation with ghc 8.8.3

### DIFF
--- a/src/Mir/Language.hs
+++ b/src/Mir/Language.hs
@@ -335,7 +335,7 @@ mirConfig = Crux.Config
 -------------------------------------------------------
 -- maybe add these to crux, as they are not specific to MIR?
 failIfNotEqual :: forall f m a (b :: k).
-                  (Monad m, Show (f a), Show (f b), TestEquality f)
+                  (MonadFail m, Show (f a), Show (f b), TestEquality f)
                => f a -> f b -> String -> m (a :~: b)
 failIfNotEqual r1 r2 str
   | Just Refl <- testEquality r1 r2 = return Refl


### PR DESCRIPTION
When building with ghc 8.8.3 I got the following error:

```
src/Mir/Language.hs:342:17: error:
    * Could not deduce (MonadFail m) arising from a use of `fail'
      from the context: (Monad m, Show (f a), Show (f b), TestEquality f)
        bound by the type signature for:
                   failIfNotEqual :: forall k (f :: k -> *) (m :: * -> *) (a :: k)
                                            (b :: k).
                                     (Monad m, Show (f a), Show (f b), TestEquality f) =>
                                     f a -> f b -> String -> m (a :~: b)
        at src/Mir/Language.hs:(337,1)-(339,53)
      Possible fix:
        add (MonadFail m) to the context of
          the type signature for:
            failIfNotEqual :: forall k (f :: k -> *) (m :: * -> *) (a :: k)
                                     (b :: k).
                              (Monad m, Show (f a), Show (f b), TestEquality f) =>
                              f a -> f b -> String -> m (a :~: b)
    * In the expression:
        fail
          $ str ++ ": mismatch between " ++ show r1 ++ " and " ++ show r2
      In an equation for `failIfNotEqual':
          failIfNotEqual r1 r2 str
            | Just Refl <- testEquality r1 r2 = return Refl
            | otherwise
            = fail
                $ str ++ ": mismatch between " ++ show r1 ++ " and " ++ show r2
    |
342 |   | otherwise = fail $ str ++ ": mismatch between " ++ show r1 ++ " and " ++ show r2
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cabal: Failed to build mir-verifier-0.1.0.0 (which is required by exe:crux-mir
from mir-verifier-0.1.0.0).
```

Adopting the suggestion fixes the compilation.